### PR TITLE
Update ReadMe to note that strings in data must be non-null or will cause a crash (issue 54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![dependencies Status](https://david-dm.org/gregnb/mui-datatables/status.svg)](https://david-dm.org/gregnb/mui-datatables)
 [![npm version](https://badge.fury.io/js/mui-datatables.svg)](https://badge.fury.io/js/mui-datatables)
 
-MUI-Datatables is a data tables component built on [Material-UI V1](https://www.material-ui-next.com).  It comes with features like filtering, view/hide columns, search, export to CSV download, printing, selectable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are two responsive modes "stacked" and "scroll" for mobile/tablet devices. 
+MUI-Datatables is a data tables component built on [Material-UI V1](https://www.material-ui-next.com).  It comes with features like filtering, view/hide columns, search, export to CSV download, printing, selectable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are two responsive modes "stacked" and "scroll" for mobile/tablet devices.
 
 <div align="center">
 	<img src="https://user-images.githubusercontent.com/19170080/38026128-eac9d506-3258-11e8-92a7-b0d06e5faa82.gif" />
@@ -44,11 +44,11 @@ const options = {
   filterType: 'checkbox',
 };
 
-<MUIDataTable 
-  title={"Employee List"} 
-  data={data} 
-  columns={columns} 
-  options={options} 
+<MUIDataTable
+  title={"Employee List"}
+  data={data}
+  columns={columns}
+  options={options}
 />
 
 ```
@@ -101,11 +101,11 @@ const options = {
   filterType: 'checkbox',
 };
 
-<MUIDataTable 
-  title={"Employee List"} 
-  data={data} 
-  columns={columns} 
-  options={options} 
+<MUIDataTable
+  title={"Employee List"}
+  data={data}
+  columns={columns}
+  options={options}
 />
 
 ```
@@ -121,7 +121,7 @@ The component accepts the following props:
 |:--:|:-----|:-----|
 |**`title`**|array|Title used to caption table
 |**`columns`**|array|Columns used to describe table. Must be either an array of simple strings or objects describing a column
-|**`data`**|array|Data used to describe table. Must be an array of simple strings
+|**`data`**|array|Data used to describe table. Must be an array of non-null simple strings
 |**`options`**|object|Options used to describe table
 
 #### Options:
@@ -208,7 +208,7 @@ class BodyCellExample extends React.Component {
   })
 
   render() {
-  
+
     return (
       <MuiThemeProvider theme={this.getMuiTheme()}>
         <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
@@ -260,7 +260,7 @@ const options = {
       deleteAria: "Delete Selected Rows",
     },
   }
-  ... 
+  ...
 }
 ```
 


### PR DESCRIPTION
The one change is 
|**`data`**|array|Data used to describe table. Must be an array of non-null simple strings 

The rest are white space.  I'm using Atom.  Is there something I should set up on the editor to not cause the white space additions?