### PR TITLE
Corrected noMatch column width, fixes #77

### DIFF
--- a/src/MUIDataTableBody.js
+++ b/src/MUIDataTableBody.js
@@ -112,7 +112,9 @@ class MUIDataTableBody extends React.Component {
           ))
         ) : (
           <MUIDataTableBodyRow options={options}>
-            <MUIDataTableBodyCell colSpan={options.selectableRows ? columns.length + 1 : columns} options={options}>
+            <MUIDataTableBodyCell
+              colSpan={options.selectableRows ? columns.length + 1 : columns.length}
+              options={options}>
               <Typography variant="subheading" className={classes.emptyTitle}>
                 {options.textLabels.body.noMatch}
               </Typography>


### PR DESCRIPTION
When selectableRows is set to false, the noMatch text is set to the number of columns.