### PR TITLE
Add a onTableChange callback to get table state upon any action

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const columns = [
    filter: true,
    sort: true,
   }
- },      
+ },
  {
   name: "Company",
   options: {
@@ -80,7 +80,7 @@ const columns = [
    filter: true,
    sort: false,
   }
- },  
+ },
  {
   name: "State",
   options: {
@@ -164,6 +164,7 @@ The component accepts the following props:
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`
 |**`onColumnViewChange`**|function||Callback function that triggers when a column view has been changed. `function(changedColumn: string, action: string) => void`
 |**`onServerRequest`**|function||Callback function that triggers when the 'serverSide' option is enabled and table state has changed. `function(action: string, tableState: object) => void`
+|**`onTableChange`**|function||Callback function that triggers for any action with the resulting table state. `function(action: string, tableState: object) => void`
 
 
 ## Customize Columns
@@ -180,7 +181,7 @@ const columns = [
   }
  },
  ...
-];  
+];
 ```
 
 #### Column:

--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ The component accepts the following props:
 |**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array) => void`
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`
 |**`onColumnViewChange`**|function||Callback function that triggers when a column view has been changed. `function(changedColumn: string, action: string) => void`
-|**`onServerRequest`**|function||Callback function that triggers when the 'serverSide' option is enabled and table state has changed. `function(action: string, tableState: object) => void`
-|**`onTableChange`**|function||Callback function that triggers for any action with the resulting table state. `function(action: string, tableState: object) => void`
+|**`onTableChange`**|function||Callback function that triggers when table state has changed. `function(action: string, tableState: object) => void`
 
 
 ## Customize Columns
@@ -278,7 +277,7 @@ If you are looking to work with remote data sets or handle pagination, filtering
 ```
 const options = {
   serverSide: true,
-  onServerRequest: (action, tableState) => {
+  onTableChange: (action, tableState) => {
     this.xhrRequest('my.api.com/tableData', result => {
       this.setState({ data: result });
     });

--- a/examples/serverside-pagination/index.js
+++ b/examples/serverside-pagination/index.js
@@ -33,13 +33,13 @@ class Example extends React.Component {
         ["Aaren Rose", "Business Analyst", "Toledo"]
       ];
 
-      const maxRound =  Math.floor(Math.random() * 2) + 1;    
+      const maxRound =  Math.floor(Math.random() * 2) + 1;
       const data = [...Array(maxRound)].reduce(acc => acc.push(...srcData) && acc, []);
       data.sort((a, b) => 0.5 - Math.random());
 
       setTimeout(() => {
         resolve(data);
-      }, 250); 
+      }, 250);
 
     });
 
@@ -47,7 +47,7 @@ class Example extends React.Component {
 
   changePage = (page) => {
     this.xhrRequest(`/myApiServer?page=${page}`).then(data => {
-      this.setState({ 
+      this.setState({
         page: page,
         data
       });
@@ -66,10 +66,10 @@ class Example extends React.Component {
       serverSide: true,
       count: count,
       page: page,
-      onServerRequest: (action, tableState) => {
+      onTableChange: (action, tableState) => {
 
         console.log(action, tableState);
-        // a developer could react to change on an action basis or 
+        // a developer could react to change on an action basis or
         // examine the state as a whole and do whatever they want
 
         switch (action) {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -193,7 +193,7 @@ class MUIDataTable extends React.Component {
     if (this.options.serverSide) {
       this.options.onServerRequest(action, this.state);
     }
-    if (this.options.onTableChange) {
+    if (typeof this.options.onTableChange === 'function') {
       this.options.onTableChange(action, this.state);
     }
   };

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -189,11 +189,11 @@ class MUIDataTable extends React.Component {
     }
   }
 
-  setTableAction = action => {
-    if (this.options.serverSide) {
+  setTableAction = (action, local = false) => {
+    if (!local && this.options.serverSide) {
       this.options.onServerRequest(action, this.state);
     }
-    if (typeof this.options.onTableChange === 'function') {
+    if (typeof this.options.onTableChange === "function") {
       this.options.onTableChange(action, this.state);
     }
   };
@@ -219,7 +219,7 @@ class MUIDataTable extends React.Component {
    *  Build the source table data
    */
 
-  setTableData(props, status) {
+  setTableData(props, status, callback = ()=>{}) {
     const { data, columns, options } = props;
 
     let columnData = [],
@@ -313,7 +313,7 @@ class MUIDataTable extends React.Component {
       selectedRows: selectedRowsData,
       data: tableData,
       displayData: this.getDisplayData(columnData, tableData, filterList, prevState.searchText),
-    }));
+    }), callback);
   }
 
   /*
@@ -450,6 +450,7 @@ class MUIDataTable extends React.Component {
         };
       },
       () => {
+        this.setTableAction("columnViewChange", true);
         if (this.options.onColumnViewChange) {
           this.options.onColumnViewChange(
             this.state.columns[index].name,
@@ -635,6 +636,9 @@ class MUIDataTable extends React.Component {
         },
       },
       TABLE_LOAD.UPDATE,
+      () => {
+        this.setTableAction("rowDelete", true);
+      }
     );
   };
 
@@ -675,7 +679,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
-          this.setTableAction("rowsSelect");
+          this.setTableAction("rowsSelect", true);
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect(this.state.curSelectedRows, this.state.selectedRows.data);
           }
@@ -709,7 +713,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
-          this.setTableAction("rowsSelect");
+          this.setTableAction("rowsSelect", true);
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect([value], this.state.selectedRows.data);
           }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -675,6 +675,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
+          this.setTableAction("rowsSelect");
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect(this.state.curSelectedRows, this.state.selectedRows.data);
           }
@@ -708,6 +709,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
+          this.setTableAction("rowsSelect");
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect([value], this.state.selectedRows.data);
           }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -76,6 +76,7 @@ class MUIDataTable extends React.Component {
       resizableColumns: PropTypes.bool,
       selectableRows: PropTypes.bool,
       serverSide: PropTypes.bool,
+      onTableChange: PropTypes.func,
       caseSensitive: PropTypes.bool,
       rowHover: PropTypes.bool,
       page: PropTypes.number,
@@ -184,15 +185,12 @@ class MUIDataTable extends React.Component {
   }
 
   validateOptions(options) {
-    if (options.serverSide && options.onServerRequest === undefined) {
-      throw Error("onServerRequest callback must be provided when using serverSide option");
+    if (options.serverSide && options.onTableChange === undefined) {
+      throw Error("onTableChange callback must be provided when using serverSide option");
     }
   }
 
-  setTableAction = (action, local = false) => {
-    if (!local && this.options.serverSide) {
-      this.options.onServerRequest(action, this.state);
-    }
+  setTableAction = (action) => {
     if (typeof this.options.onTableChange === "function") {
       this.options.onTableChange(action, this.state);
     }
@@ -453,7 +451,7 @@ class MUIDataTable extends React.Component {
         };
       },
       () => {
-        this.setTableAction("columnViewChange", true);
+        this.setTableAction("columnViewChange");
         if (this.options.onColumnViewChange) {
           this.options.onColumnViewChange(
             this.state.columns[index].name,
@@ -640,7 +638,7 @@ class MUIDataTable extends React.Component {
       },
       TABLE_LOAD.UPDATE,
       () => {
-        this.setTableAction("rowDelete", true);
+        this.setTableAction("rowDelete");
       },
     );
   };
@@ -682,7 +680,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
-          this.setTableAction("rowsSelect", true);
+          this.setTableAction("rowsSelect");
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect(this.state.curSelectedRows, this.state.selectedRows.data);
           }
@@ -716,7 +714,7 @@ class MUIDataTable extends React.Component {
           };
         },
         () => {
-          this.setTableAction("rowsSelect", true);
+          this.setTableAction("rowsSelect");
           if (this.options.onRowsSelect) {
             this.options.onRowsSelect([value], this.state.selectedRows.data);
           }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -219,7 +219,7 @@ class MUIDataTable extends React.Component {
    *  Build the source table data
    */
 
-  setTableData(props, status, callback = ()=>{}) {
+  setTableData(props, status, callback = () => {}) {
     const { data, columns, options } = props;
 
     let columnData = [],
@@ -306,14 +306,17 @@ class MUIDataTable extends React.Component {
     }
 
     /* set source data and display Data set source set */
-    this.setState(prevState => ({
-      columns: columnData,
-      filterData: filterData,
-      filterList: filterList,
-      selectedRows: selectedRowsData,
-      data: tableData,
-      displayData: this.getDisplayData(columnData, tableData, filterList, prevState.searchText),
-    }), callback);
+    this.setState(
+      prevState => ({
+        columns: columnData,
+        filterData: filterData,
+        filterList: filterList,
+        selectedRows: selectedRowsData,
+        data: tableData,
+        displayData: this.getDisplayData(columnData, tableData, filterList, prevState.searchText),
+      }),
+      callback,
+    );
   }
 
   /*
@@ -638,7 +641,7 @@ class MUIDataTable extends React.Component {
       TABLE_LOAD.UPDATE,
       () => {
         this.setTableAction("rowDelete", true);
-      }
+      },
     );
   };
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -189,9 +189,12 @@ class MUIDataTable extends React.Component {
     }
   }
 
-  setServerRequest = action => {
+  setTableAction = action => {
     if (this.options.serverSide) {
       this.options.onServerRequest(action, this.state);
+    }
+    if (this.options.onTableChange) {
+      this.options.onTableChange(action, this.state);
     }
   };
 
@@ -506,7 +509,7 @@ class MUIDataTable extends React.Component {
         return newState;
       },
       () => {
-        this.setServerRequest("sort");
+        this.setTableAction("sort");
         if (this.options.onColumnSortChange) {
           this.options.onColumnSortChange(
             this.state.columns[index].name,
@@ -523,7 +526,7 @@ class MUIDataTable extends React.Component {
         rowsPerPage: rows,
       }),
       () => {
-        this.setServerRequest("changeRowsPerPage");
+        this.setTableAction("changeRowsPerPage");
         if (this.options.onChangeRowsPerPage) {
           this.options.onChangeRowsPerPage(this.state.rowsPerPage);
         }
@@ -537,7 +540,7 @@ class MUIDataTable extends React.Component {
         page: page,
       }),
       () => {
-        this.setServerRequest("changePage");
+        this.setTableAction("changePage");
         if (this.options.onChangePage) {
           this.options.onChangePage(this.state.page);
         }
@@ -554,7 +557,7 @@ class MUIDataTable extends React.Component {
           : this.getDisplayData(prevState.columns, prevState.data, prevState.filterList, text),
       }),
       () => {
-        this.setServerRequest("search");
+        this.setTableAction("search");
       },
     );
   };
@@ -572,7 +575,7 @@ class MUIDataTable extends React.Component {
         };
       },
       () => {
-        this.setServerRequest("resetFilters");
+        this.setTableAction("resetFilters");
         if (this.options.onFilterChange) {
           this.options.onFilterChange(null, this.state.filterList);
         }
@@ -605,7 +608,7 @@ class MUIDataTable extends React.Component {
         };
       },
       () => {
-        this.setServerRequest("filterChange");
+        this.setTableAction("filterChange");
         if (this.options.onFilterChange) {
           this.options.onFilterChange(column, this.state.filterList);
         }

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { spy } from "sinon";
+import { spy, stub } from "sinon";
 import { mount, shallow } from "enzyme";
 import { assert, expect, should } from "chai";
 import MUIDataTable from "../src/MUIDataTable";
@@ -429,5 +429,36 @@ describe("<MUIDataTable />", function() {
 
     const state = shallowWrapper.state();
     assert.deepEqual(state.data[0].data[2], "Las Vegas");
+  });
+  it("should call onTableChange when calling selectRowUpdate method with type=head", () => {
+    const options = { selectableRows: true, onTableChange: spy() };
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />).dive();
+    const instance = shallowWrapper.instance();
+
+    instance.selectRowUpdate("head", 0);
+    shallowWrapper.update();
+
+    const state = shallowWrapper.state();
+    const expectedResult = [
+      { index: 0, dataIndex: 0 },
+      { index: 1, dataIndex: 1 },
+      { index: 2, dataIndex: 2 },
+      { index: 3, dataIndex: 3 },
+    ];
+    assert.deepEqual(state.selectedRows.data, expectedResult);
+    assert.strictEqual(options.onTableChange.callCount, 1);
+  });
+  it("should call onTableChange when calling selectRowUpdate method with type=cell", () => {
+    const options = { selectableRows: true, onTableChange: spy() };
+
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />).dive();
+    const instance = shallowWrapper.instance();
+
+    instance.selectRowUpdate("cell", 0);
+    shallowWrapper.update();
+
+    const state = shallowWrapper.state();
+    assert.deepEqual(state.selectedRows.data, [0]);
+    assert.strictEqual(options.onTableChange.callCount, 1);
   });
 });


### PR DESCRIPTION
I'd like to be able to subscribe to the table state as a whole for any action regardless of the serverSide option, in order to treat the table as more of a controlled component.

Usecase: I want to allow a user to change the shape of the table and save the structure. I am using the table as form component of sorts.

I've started with piggybacking on the setServerRequest (renamed to setTableAction), and continued with selectRowUpdate, selectRowDelete and columnViewChange.

If this is helpful and desired, great. If you think there is a better route let me know :)

Cheers,
JP