### PR TITLE
Perform search only if serverSide is falsy

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -360,7 +360,7 @@ class MUIDataTable extends React.Component {
 
       const columnVal = columnValue === null ? "" : columnValue.toString();
 
-      if (searchText) {
+      if (searchText && !this.options.serverSide) {
         let searchNeedle = searchText.toString();
         let searchStack = columnVal.toString();
 


### PR DESCRIPTION
Currently, during the search when the server side data is passed on to the datatable, it again filters the data using local search logic. In the `computeDisplayRow()` function, it doesn't check if the `options.serverSide` is false or not. 