### PR TITLE
Perform search only if serverSide is falsy

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -375,7 +375,7 @@ class MUIDataTable extends React.Component {
       }
     }
 
-    if (isFiltered || (searchText && !isSearchFound)) return null;
+    if (isFiltered || (!this.options.serverSide && searchText && !isSearchFound)) return null;
     else return displayRow;
   }
 


### PR DESCRIPTION
Currently, during the search when the server side data is passed on to the datatable, it again filters the data using local search logic. In the computeDisplayRow() function, it doesn't check if the options.serverSide is false or not.