### PR TITLE
Expose `dataIndex` during `onCellClick` event handler

### DIFF
--- a/src/MUIDataTableBodyCell.js
+++ b/src/MUIDataTableBodyCell.js
@@ -33,7 +33,7 @@ class MUIDataTableBodyCell extends React.Component {
   handleClick = () => {
     const { colIndex, options, children, dataIndex, rowIndex } = this.props;
     if (options.onCellClick) {
-      options.onCellClick(children, { colIndex, rowIndex });
+      options.onCellClick(children, { colIndex, rowIndex, dataIndex });
     }
   };
 


### PR DESCRIPTION
The `onCellClick` handler currently exposes the `colIndex` and `rowIndex` but these are relative to what's currently on screen rather than the complete data array. This change additionally exposes the `dataIndex`, which _does_ relate to the data array.

I've put together [an example](https://codesandbox.io/s/7wmwokz6p1) of the problem this will help fix. If you click a row in the list, the employee's name will appear below the table. If you then filter the table to "Bob" and click the filtered row, the name will say "Joe James" because `rowIndex` is "0" and that's the first item in the data array. `dataIndex` would return "2" allowing you to accurately access Bob's details.

The real-world problem I'm trying to solve here is making the row like a hyperlink, so clicking on a cell in it will open that employee's details.