### PR TITLE
New onSearchOpen Callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ The component accepts the following props:
 |**`onChangePage`**|function||Callback function that triggers when a page has changed. `function(currentPage: number) => void`
 |**`onChangeRowsPerPage`**|function||Callback function that triggers when the number of rows per page has changed. `function(numberOfRows: number) => void`
 |**`onSearchChange`**|function||Callback function that triggers when the search text value has changed. `function(searchText: string) => void`
-|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array) => void`
+|**`onSearchOpen`**|function||Callback function that triggers when the searchbox opens. `function() => void`
+|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array) => 
+void`
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`
 |**`onColumnViewChange`**|function||Callback function that triggers when a column view has been changed. `function(changedColumn: string, action: string) => void`
 |**`onTableChange`**|function||Callback function that triggers when table state has changed. `function(action: string, tableState: object) => void`

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -802,6 +802,7 @@ class MUIDataTable extends React.Component {
             tableRef={() => this.tableContent}
             title={title}
             toggleViewColumn={this.toggleViewColumn}
+            setTableAction={this.setTableAction}
           />
         )}
         <MUIDataTableFilterList options={this.options} filterList={filterList} filterUpdate={this.filterUpdate} />

--- a/src/MUIDataTableToolbar.js
+++ b/src/MUIDataTableToolbar.js
@@ -137,6 +137,7 @@ class MUIDataTableToolbar extends React.Component {
 
   showSearch = () => {
     !!this.props.options.onSearchOpen && this.props.options.onSearchOpen();
+    this.props.setTableAction("onSearchOpen");
     return true;
   }
 

--- a/src/MUIDataTableToolbar.js
+++ b/src/MUIDataTableToolbar.js
@@ -127,13 +127,18 @@ class MUIDataTableToolbar extends React.Component {
   setActiveIcon = iconName => {
     this.setState(() => ({
       iconActive: iconName,
-      showSearch: iconName === "search" ? true : false,
+      showSearch: iconName === "search" ? this.showSearch() : false,
     }));
   };
 
   getActiveIcon = (styles, iconName) => {
     return this.state.iconActive !== iconName ? styles.icon : styles.iconActive;
   };
+
+  showSearch = () => {
+    !!this.props.options.onSearchOpen && this.props.options.onSearchOpen();
+    return true;
+  }
 
   hideSearch = () => {
     const { onSearchClose } = this.props.options;


### PR DESCRIPTION
This PR adds a new `onSearchOpen` callback triggered when the search box is displayed and also closes https://github.com/gregnb/mui-datatables/issues/210

Example of how to use this callback:
```
    const options = {
      filter: true,
      filterType: 'dropdown',
      responsive: 'stacked',
      onSearchOpen: ()=>{
       // your code here will be run after the user opens the search box
      },
    };

    return (
      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
    );
```