### PR TITLE
Use MUI theme breakpoint media queries

### DIFF
--- a/src/MUIDataTableBodyCell.js
+++ b/src/MUIDataTableBodyCell.js
@@ -3,13 +3,13 @@ import classNames from "classnames";
 import TableCell from "@material-ui/core/TableCell";
 import { withStyles } from "@material-ui/core/styles";
 
-const defaultBodyCellStyles = {
+const defaultBodyCellStyles = theme => ({
   root: {},
   cellHide: {
     display: "none",
   },
   cellStacked: {
-    "@media screen and (max-width: 960px)": {
+    [theme.breakpoints.down("sm")]: {
       display: "inline-block",
       backgroundColor: "#FFF",
       fontSize: "16px",
@@ -19,7 +19,7 @@ const defaultBodyCellStyles = {
     },
   },
   responsiveStacked: {
-    "@media screen and (max-width: 960px)": {
+    [theme.breakpoints.down("sm")]: {
       display: "inline-block",
       fontSize: "16px",
       width: "calc(50% - 80px)",
@@ -27,7 +27,7 @@ const defaultBodyCellStyles = {
       height: "24px",
     },
   },
-};
+});
 
 class MUIDataTableBodyCell extends React.Component {
   handleClick = () => {

--- a/src/MUIDataTableBodyRow.js
+++ b/src/MUIDataTableBodyRow.js
@@ -4,14 +4,14 @@ import classNames from "classnames";
 import TableRow from "@material-ui/core/TableRow";
 import { withStyles } from "@material-ui/core/styles";
 
-const defaultBodyRowStyles = {
+const defaultBodyRowStyles = theme => ({
   root: {},
   responsiveStacked: {
-    "@media screen and (max-width: 960px)": {
+    [theme.breakpoints.down("sm")]: {
       border: "solid 2px rgba(0, 0, 0, 0.15)",
     },
   },
-};
+});
 
 class MUIDataTableBodyRow extends React.Component {
   static propTypes = {

--- a/src/MUIDataTableHead.js
+++ b/src/MUIDataTableHead.js
@@ -7,14 +7,14 @@ import MUIDataTableHeadCell from "./MUIDataTableHeadCell";
 import MUIDataTableSelectCell from "./MUIDataTableSelectCell";
 import { withStyles } from "@material-ui/core/styles";
 
-const defaultHeadStyles = {
+const defaultHeadStyles = theme => ({
   main: {},
   responsiveStacked: {
-    "@media screen and (max-width: 960px)": {
+    [theme.breakpoints.down("sm")]: {
       display: "none",
     },
   },
-};
+});
 
 class MUIDataTableHead extends React.Component {
   componentDidMount() {

--- a/src/MUIDataTableSelectCell.js
+++ b/src/MUIDataTableSelectCell.js
@@ -5,9 +5,9 @@ import Checkbox from "@material-ui/core/Checkbox";
 import TableCell from "@material-ui/core/TableCell";
 import { withStyles } from "@material-ui/core/styles";
 
-const defaultSelectCellStyles = {
+const defaultSelectCellStyles = theme => ({
   root: {
-    "@media screen and (max-width: 960px)": {
+    [theme.breakpoints.down("sm")]: {
       display: "none",
     },
   },
@@ -25,7 +25,7 @@ const defaultSelectCellStyles = {
   },
   checked: {},
   disabled: {},
-};
+});
 
 class MUIDataTableSelectCell extends React.Component {
   static propTypes = {

--- a/src/MUIDataTableToolbar.js
+++ b/src/MUIDataTableToolbar.js
@@ -39,11 +39,11 @@ export const defaultToolbarStyles = (theme, props) => ({
     marginTop: "10px",
     marginRight: "8px",
   },
-  ...(props.options.responsive ? { ...responsiveToolbarStyles } : {}),
+  ...(props.options.responsive ? { ...responsiveToolbarStyles(theme) } : {}),
 });
 
-export const responsiveToolbarStyles = {
-  "@media screen and (max-width: 960px)": {
+export const responsiveToolbarStyles = theme => ({
+  [theme.breakpoints.down("sm")]: {
     titleRoot: {},
     titleText: {
       fontSize: "16px",
@@ -60,7 +60,7 @@ export const responsiveToolbarStyles = {
       textAlign: "right",
     },
   },
-  "@media screen and (max-width: 600px)": {
+  [theme.breakpoints.down("xs")]: {
     root: {
       display: "block",
     },
@@ -75,7 +75,7 @@ export const responsiveToolbarStyles = {
     },
   },
   "@media screen and (max-width: 480px)": {},
-};
+});
 
 class MUIDataTableToolbar extends React.Component {
   state = {


### PR DESCRIPTION
Using the MUI theme breakpoints prevents off-by-one incongruencies with
applications rendering datatables using the default breakpoints. It also
enables application developers to customize the MUI breakpoints without
jarring experience when using `mui-datatables`. Closes #269.

NOTE: There were a couple places with very small media queries which don't have a MUI equivalent. I left those media queries intact: [MUIDataTablePagination](https://github.com/gregnb/mui-datatables/blob/0297bb6b21effdf1a6d4264e22b8b1307020140b/src/MUIDataTablePagination.js#L16) and [MUIDataTableToolbar](https://github.com/gregnb/mui-datatables/blob/0297bb6b21effdf1a6d4264e22b8b1307020140b/src/MUIDataTableToolbar.js#L77) (specifies no styles?)

### Testing Procedure

I manually verified that each of the updated media queries worked as expected in Chrome. (Thankfully, otherwise I might not have noticed the [conditional spread of responsive styles](https://github.com/gregnb/mui-datatables/blob/0297bb6b21effdf1a6d4264e22b8b1307020140b/src/MUIDataTableToolbar.js#L42).)