### PR TITLE
Feature detect "Intl" and use plain string comparison when not available

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -15,15 +15,15 @@ import isEqual from "lodash.isequal";
 import textLabels from "./textLabels";
 import { withStyles } from "@material-ui/core/styles";
 
-const standardCollator = (a, b) => a.localeCompare(b);
+export const fallbackComparator = (a, b) => a.localeCompare(b);
 
-const getCollatorComparison = () => {
+export const getCollatzComparator = () => {
   if (!!Intl) {
     const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
     return collator.compare;
   }
 
-  return standardCollator;
+  return fallbackComparator;
 }
 
 const defaultTableStyles = {
@@ -315,7 +315,7 @@ class MUIDataTable extends React.Component {
       }
 
       if (this.options.sortFilterList) {
-        const comparator = getCollatorComparison();
+        const comparator = getCollatzComparator();
         filterData[colIndex].sort(comparator);
       }
     });
@@ -435,7 +435,7 @@ class MUIDataTable extends React.Component {
       changedData[row].data[index] = value;
 
       if (this.options.sortFilterList) {
-        const comparator = getCollatorComparison();
+        const comparator = getCollatzComparator();
         filterData[index].sort(comparator);
       }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -15,17 +15,6 @@ import isEqual from "lodash.isequal";
 import textLabels from "./textLabels";
 import { withStyles } from "@material-ui/core/styles";
 
-export const fallbackComparator = (a, b) => a.localeCompare(b);
-
-export const getCollatzComparator = () => {
-  if (!!Intl) {
-    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-    return collator.compare;
-  }
-
-  return fallbackComparator;
-}
-
 const defaultTableStyles = {
   root: {},
   responsiveScroll: {
@@ -164,6 +153,17 @@ class MUIDataTable extends React.Component {
     this.getDefaultOptions(props);
     this.setTableOptions(props);
     this.setTableData(props, TABLE_LOAD.INITIAL);
+  }
+
+  static fallbackComparator = (a, b) => a.localeCompare(b);
+
+  static getCollatzComparator = () => {
+    if (!!Intl) {
+      const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+      return collator.compare;
+    }
+
+    return MUIDataTable.fallbackComparator;
   }
 
   /*
@@ -315,7 +315,7 @@ class MUIDataTable extends React.Component {
       }
 
       if (this.options.sortFilterList) {
-        const comparator = getCollatzComparator();
+        const comparator = MUIDataTable.getCollatzComparator();
         filterData[colIndex].sort(comparator);
       }
     });
@@ -435,7 +435,7 @@ class MUIDataTable extends React.Component {
       changedData[row].data[index] = value;
 
       if (this.options.sortFilterList) {
-        const comparator = getCollatzComparator();
+        const comparator = MUIDataTable.getCollatzComparator();
         filterData[index].sort(comparator);
       }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -15,6 +15,17 @@ import isEqual from "lodash.isequal";
 import textLabels from "./textLabels";
 import { withStyles } from "@material-ui/core/styles";
 
+const standardCollator = (a, b) => a.localeCompare(b);
+
+const getCollatorComparison = () => {
+  if (!!Intl) {
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+    return collator.compare;
+  }
+
+  return standardCollator;
+}
+
 const defaultTableStyles = {
   root: {},
   responsiveScroll: {
@@ -304,8 +315,8 @@ class MUIDataTable extends React.Component {
       }
 
       if (this.options.sortFilterList) {
-        const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-        filterData[colIndex].sort(collator.compare);
+        const comparator = getCollatorComparison();
+        filterData[colIndex].sort(comparator);
       }
     });
 
@@ -424,8 +435,8 @@ class MUIDataTable extends React.Component {
       changedData[row].data[index] = value;
 
       if (this.options.sortFilterList) {
-        const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-        filterData[index].sort(collator.compare);
+        const comparator = getCollatorComparison();
+        filterData[index].sort(comparator);
       }
 
       return {

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -1,13 +1,53 @@
 import React from "react";
-import { spy, stub } from "sinon";
+import { spy } from "sinon";
 import { mount, shallow } from "enzyme";
-import { assert, expect, should } from "chai";
-import MUIDataTable from "../src/MUIDataTable";
+import { assert, expect } from "chai";
+import MUIDataTable, { fallbackComparator, getCollatzComparator } from "../src/MUIDataTable";
 import MUIDataTableFilterList from "../src/MUIDataTableFilterList";
 import MUIDataTablePagination from "../src/MUIDataTablePagination";
 import textLabels from "../src/textLabels";
 import Chip from "@material-ui/core/Chip";
 import Cities from "../examples/component/cities";
+
+describe("fallbackComparator", () => {
+  
+  it("correctly compares two equal strings", () => {
+    expect(fallbackComparator("testString", "testString")).to.equal(0);
+  });
+
+  it("correctly compares two different strings", () => {
+    expect(fallbackComparator("testStringA", "testStringB")).to.equal(-1);
+  });
+
+});
+
+describe("getCollatzComparator", () => {
+
+  describe("when Intl is available", () => {
+    it("returns a collator object", () => {
+      const comparator = getCollatzComparator();
+
+      expect(comparator).not.to.equal(fallbackComparator);
+    });
+
+  });
+
+  describe("when Intl is not available", () => {
+    
+    it("returns the fallback comparator", () => {
+      const _intl = global.Intl;
+      global.Intl = undefined;
+
+      const comparator = getCollatzComparator();
+
+      global.Intl = _intl;
+
+      expect(comparator).to.equal(fallbackComparator);
+    });
+
+  });
+
+});
 
 describe("<MUIDataTable />", function() {
   let data;

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -2,52 +2,12 @@ import React from "react";
 import { spy } from "sinon";
 import { mount, shallow } from "enzyme";
 import { assert, expect } from "chai";
-import MUIDataTable, { fallbackComparator, getCollatzComparator } from "../src/MUIDataTable";
+import MUIDataTable from "../src/MUIDataTable";
 import MUIDataTableFilterList from "../src/MUIDataTableFilterList";
 import MUIDataTablePagination from "../src/MUIDataTablePagination";
 import textLabels from "../src/textLabels";
 import Chip from "@material-ui/core/Chip";
 import Cities from "../examples/component/cities";
-
-describe("fallbackComparator", () => {
-  
-  it("correctly compares two equal strings", () => {
-    expect(fallbackComparator("testString", "testString")).to.equal(0);
-  });
-
-  it("correctly compares two different strings", () => {
-    expect(fallbackComparator("testStringA", "testStringB")).to.equal(-1);
-  });
-
-});
-
-describe("getCollatzComparator", () => {
-
-  describe("when Intl is available", () => {
-    it("returns a collator object", () => {
-      const comparator = getCollatzComparator();
-
-      expect(comparator).not.to.equal(fallbackComparator);
-    });
-
-  });
-
-  describe("when Intl is not available", () => {
-    
-    it("returns the fallback comparator", () => {
-      const _intl = global.Intl;
-      global.Intl = undefined;
-
-      const comparator = getCollatzComparator();
-
-      global.Intl = _intl;
-
-      expect(comparator).to.equal(fallbackComparator);
-    });
-
-  });
-
-});
 
 describe("<MUIDataTable />", function() {
   let data;
@@ -543,4 +503,47 @@ describe("<MUIDataTable />", function() {
     assert.deepEqual(state.selectedRows.data, expectedResult);
     assert.strictEqual(options.onTableChange.callCount, 1);
   });
+
+
+
+  describe("fallbackComparator", () => {
+    
+    it("correctly compares two equal strings", () => {
+      expect(MUIDataTable.fallbackComparator("testString", "testString")).to.equal(0);
+    });
+
+    it("correctly compares two different strings", () => {
+      expect(MUIDataTable.fallbackComparator("testStringA", "testStringB")).to.equal(-1);
+    });
+
+  });
+
+  describe("getCollatzComparator", () => {
+
+    describe("when Intl is available", () => {
+      it("returns a collator object", () => {
+        const comparator = MUIDataTable.getCollatzComparator();
+  
+        expect(comparator).not.to.equal(MUIDataTable.fallbackComparator);
+      });
+  
+    });
+  
+    describe("when Intl is not available", () => {
+      
+      it("returns the fallback comparator", () => {
+        const _intl = global.Intl;
+        global.Intl = undefined;
+
+        const comparator = MUIDataTable.getCollatzComparator();
+  
+        global.Intl = _intl;
+  
+        expect(comparator).to.equal(MUIDataTable.fallbackComparator);
+      });
+  
+    });
+  
+  });
+
 });


### PR DESCRIPTION
First of all, thank you for creating this great package!

I recently discovered that in some browsers (like Android Web View or older versions of mobile Safari), there is no support for the `Intl` API. In order to prevent crashes on these devices, I propose to feature detect for `Intl` and fall back to a plain string comparison in cases where `Intl` is not available.