### PR TITLE
#252: fix filter re-render bug 

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -131,6 +131,7 @@ class MUIDataTable extends React.Component {
   constructor() {
     super();
     this.tableRef = false;
+    this.tableContent = React.createRef();
     this.headCellRefs = {};
     this.setHeadResizeable = () => {};
   }
@@ -820,6 +821,12 @@ class MUIDataTable extends React.Component {
     };
   }
 
+  // must be arrow function on local field to refer to the correct instance when passed around
+  // assigning it as arrow function in the JSX would cause hard to track re-render errors
+  getTableContentRef = () => {
+    return this.tableContent.current;
+  };
+
   render() {
     const { classes, title } = this.props;
     const {
@@ -839,7 +846,7 @@ class MUIDataTable extends React.Component {
     const rowCount = this.options.count || displayData.length;
 
     return (
-      <Paper elevation={4} ref={el => (this.tableContent = el)} className={classes.paper}>
+      <Paper elevation={4} ref={this.tableContent} className={classes.paper}>
         {selectedRows.data.length ? (
           <MUIDataTableToolbarSelect
             options={this.options}
@@ -859,7 +866,7 @@ class MUIDataTable extends React.Component {
             options={this.options}
             resetFilters={this.resetFilters}
             searchTextUpdate={this.searchTextUpdate}
-            tableRef={() => this.tableContent}
+            tableRef={this.getTableContentRef}
             title={title}
             toggleViewColumn={this.toggleViewColumn}
             setTableAction={this.setTableAction}

--- a/src/MUIDataTableToolbar.js
+++ b/src/MUIDataTableToolbar.js
@@ -3,7 +3,6 @@ import Typography from "@material-ui/core/Typography";
 import Toolbar from "@material-ui/core/Toolbar";
 import Tooltip from "@material-ui/core/Tooltip";
 import IconButton from "@material-ui/core/IconButton";
-import { MUIPopover, MUIPopoverTarget, MUIPopoverContent } from "./MUIPopover";
 import MUIDataTableFilter from "./MUIDataTableFilter";
 import MUIDataTableViewCol from "./MUIDataTableViewCol";
 import MUIDataTableSearch from "./MUIDataTableSearch";
@@ -14,6 +13,7 @@ import ViewColumnIcon from "@material-ui/icons/ViewColumn";
 import FilterIcon from "@material-ui/icons/FilterList";
 import ReactToPrint from "react-to-print";
 import styled from "./styled";
+import MUIDataTablePopoverWrapper from "./MUIPopover/MUIDataTablePopoverWrapper";
 
 export const defaultToolbarStyles = (theme, props) => ({
   root: {},
@@ -39,7 +39,7 @@ export const defaultToolbarStyles = (theme, props) => ({
     marginTop: "10px",
     marginRight: "8px",
   },
-  ...(props.options.responsive ? { ...responsiveToolbarStyles(theme) } : {}),
+  ...(props.options.responsive ? {...responsiveToolbarStyles(theme)} : {}),
 });
 
 export const responsiveToolbarStyles = theme => ({
@@ -84,16 +84,16 @@ class MUIDataTableToolbar extends React.Component {
   };
 
   handleCSVDownload = () => {
-    const { data, columns, options } = this.props;
+    const {data, columns, options} = this.props;
 
     const CSVHead =
-      columns
-        .reduce(
-          (soFar, column) =>
-            column.download ? soFar + '"' + column.name + '"' + options.downloadOptions.separator : soFar,
-          "",
-        )
-        .slice(0, -1) + "\r\n";
+            columns
+              .reduce(
+                (soFar, column) =>
+                  column.download ? soFar + '"' + column.name + '"' + options.downloadOptions.separator : soFar,
+                "",
+              )
+              .slice(0, -1) + "\r\n";
 
     const CSVBody = data
       .reduce(
@@ -101,8 +101,8 @@ class MUIDataTableToolbar extends React.Component {
           soFar +
           '"' +
           row.data
-            .filter((field, index) => columns[index].download)
-            .join('"' + options.downloadOptions.separator + '"') +
+             .filter((field, index) => columns[index].download)
+             .join('"' + options.downloadOptions.separator + '"') +
           '"\r\n',
         [],
       )
@@ -162,124 +162,105 @@ class MUIDataTableToolbar extends React.Component {
 
   render() {
     const {
-      data,
-      options,
-      classes,
-      columns,
-      filterData,
-      filterList,
-      filterUpdate,
-      resetFilters,
-      searchTextUpdate,
-      toggleViewColumn,
-      title,
-      tableRef,
-    } = this.props;
+            data,
+            options,
+            classes,
+            columns,
+            filterData,
+            filterList,
+            filterUpdate,
+            resetFilters,
+            searchTextUpdate,
+            toggleViewColumn,
+            title,
+            tableRef,
+          } = this.props;
 
-    const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
-    const { showSearch } = this.state;
+    const {search, downloadCsv, print, viewColumns, filterTable} = options.textLabels.toolbar;
+    const {showSearch} = this.state;
 
     return (
       <Toolbar className={classes.root} role={"toolbar"} aria-label={"Table Toolbar"}>
         <div className={classes.left}>
           {showSearch === true ? (
-            <MUIDataTableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options} />
+            <MUIDataTableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options}/>
           ) : (
-            <div className={classes.titleRoot} aria-hidden={"true"}>
-              <Typography variant="h6" className={classes.titleText}>
-                {title}
-              </Typography>
-            </div>
-          )}
+             <div className={classes.titleRoot} aria-hidden={"true"}>
+               <Typography variant="h6" className={classes.titleText}>
+                 {title}
+               </Typography>
+             </div>
+           )}
         </div>
         <div className={classes.actions}>
-          {options.search ? (
+
+          {options.search && (
             <Tooltip title={search}>
               <IconButton
                 aria-label={search}
                 buttonRef={el => (this.searchButton = el)}
-                classes={{ root: this.getActiveIcon(classes, "search") }}
+                classes={{root: this.getActiveIcon(classes, "search")}}
                 onClick={this.setActiveIcon.bind(null, "search")}>
-                <SearchIcon />
+                <SearchIcon/>
               </IconButton>
             </Tooltip>
-          ) : (
-            false
           )}
-          {options.download ? (
+
+          {options.download && (
             <Tooltip title={downloadCsv}>
-              <IconButton aria-label={downloadCsv} classes={{ root: classes.icon }} onClick={this.handleCSVDownload}>
-                <DownloadIcon />
+              <IconButton aria-label={downloadCsv} classes={{root: classes.icon}} onClick={this.handleCSVDownload}>
+                <DownloadIcon/>
               </IconButton>
             </Tooltip>
-          ) : (
-            false
           )}
-          {options.print ? (
+
+          {options.print && (
             <Tooltip title={print}>
               <span>
                 <ReactToPrint
                   trigger={() => (
-                    <IconButton aria-label={print} classes={{ root: classes.icon }}>
-                      <PrintIcon />
+                    <IconButton aria-label={print} classes={{root: classes.icon}}>
+                      <PrintIcon/>
                     </IconButton>
                   )}
                   content={() => this.props.tableRef()}
                 />
               </span>
             </Tooltip>
-          ) : (
-            false
           )}
-          {options.viewColumns ? (
-            <MUIPopover refExit={this.setActiveIcon.bind(null)} container={tableRef}>
-              <MUIPopoverTarget>
-                <IconButton
-                  aria-label={viewColumns}
-                  classes={{ root: this.getActiveIcon(classes, "viewcolumns") }}
-                  onClick={this.setActiveIcon.bind(null, "viewcolumns")}>
-                  <Tooltip title={viewColumns}>
-                    <ViewColumnIcon />
-                  </Tooltip>
-                </IconButton>
-              </MUIPopoverTarget>
-              <MUIPopoverContent>
-                <MUIDataTableViewCol
+
+          {options.viewColumns && (
+            <MUIDataTablePopoverWrapper label={viewColumns}
+                                        tableRef={tableRef}
+                                        onClick={this.setActiveIcon.bind(null, "viewcolumns")}
+                                        buttonRoot={this.getActiveIcon(classes, "viewcolumns")}
+                                        icon={<ViewColumnIcon/>}
+                                        classes={classes}>
+              <MUIDataTableViewCol
                   data={data}
                   columns={columns}
                   options={options}
                   onColumnUpdate={toggleViewColumn}
                 />
-              </MUIPopoverContent>
-            </MUIPopover>
-          ) : (
-            false
+            </MUIDataTablePopoverWrapper>
           )}
-          {options.filter ? (
-            <MUIPopover refExit={this.setActiveIcon.bind(null)} container={tableRef}>
-              <MUIPopoverTarget>
-                <IconButton
-                  aria-label={filterTable}
-                  classes={{ root: this.getActiveIcon(classes, "filter") }}
-                  onClick={this.setActiveIcon.bind(null, "filter")}>
-                  <Tooltip title={filterTable}>
-                    <FilterIcon />
-                  </Tooltip>
-                </IconButton>
-              </MUIPopoverTarget>
-              <MUIPopoverContent>
-                <MUIDataTableFilter
-                  columns={columns}
-                  options={options}
-                  filterList={filterList}
-                  filterData={filterData}
-                  onFilterUpdate={filterUpdate}
-                  onFilterReset={resetFilters}
-                />
-              </MUIPopoverContent>
-            </MUIPopover>
-          ) : (
-            false
+
+          {options.filter && (
+            <MUIDataTablePopoverWrapper label={filterTable}
+                                        tableRef={tableRef}
+                                        onClick={this.setActiveIcon.bind(null, "filter")}
+                                        buttonRoot={this.getActiveIcon(classes, "filter")}
+                                        icon={<FilterIcon/>}
+                                        classes={classes}>
+              <MUIDataTableFilter
+                columns={columns}
+                options={options}
+                filterList={filterList}
+                filterData={filterData}
+                onFilterUpdate={filterUpdate}
+                onFilterReset={resetFilters}
+              />
+            </MUIDataTablePopoverWrapper>
           )}
           {options.customToolbar ? options.customToolbar() : false}
         </div>
@@ -288,4 +269,4 @@ class MUIDataTableToolbar extends React.Component {
   }
 }
 
-export default styled(MUIDataTableToolbar)(defaultToolbarStyles, { name: "MUIDataTableToolbar" });
+export default styled(MUIDataTableToolbar)(defaultToolbarStyles, {name: "MUIDataTableToolbar"});

--- a/src/MUIDataTableToolbar.js
+++ b/src/MUIDataTableToolbar.js
@@ -39,7 +39,7 @@ export const defaultToolbarStyles = (theme, props) => ({
     marginTop: "10px",
     marginRight: "8px",
   },
-  ...(props.options.responsive ? {...responsiveToolbarStyles(theme)} : {}),
+  ...(props.options.responsive ? { ...responsiveToolbarStyles(theme) } : {}),
 });
 
 export const responsiveToolbarStyles = theme => ({
@@ -84,16 +84,16 @@ class MUIDataTableToolbar extends React.Component {
   };
 
   handleCSVDownload = () => {
-    const {data, columns, options} = this.props;
+    const { data, columns, options } = this.props;
 
     const CSVHead =
-            columns
-              .reduce(
-                (soFar, column) =>
-                  column.download ? soFar + '"' + column.name + '"' + options.downloadOptions.separator : soFar,
-                "",
-              )
-              .slice(0, -1) + "\r\n";
+      columns
+        .reduce(
+          (soFar, column) =>
+            column.download ? soFar + '"' + column.name + '"' + options.downloadOptions.separator : soFar,
+          "",
+        )
+        .slice(0, -1) + "\r\n";
 
     const CSVBody = data
       .reduce(
@@ -101,8 +101,8 @@ class MUIDataTableToolbar extends React.Component {
           soFar +
           '"' +
           row.data
-             .filter((field, index) => columns[index].download)
-             .join('"' + options.downloadOptions.separator + '"') +
+            .filter((field, index) => columns[index].download)
+            .join('"' + options.downloadOptions.separator + '"') +
           '"\r\n',
         [],
       )
@@ -162,54 +162,53 @@ class MUIDataTableToolbar extends React.Component {
 
   render() {
     const {
-            data,
-            options,
-            classes,
-            columns,
-            filterData,
-            filterList,
-            filterUpdate,
-            resetFilters,
-            searchTextUpdate,
-            toggleViewColumn,
-            title,
-            tableRef,
-          } = this.props;
+      data,
+      options,
+      classes,
+      columns,
+      filterData,
+      filterList,
+      filterUpdate,
+      resetFilters,
+      searchTextUpdate,
+      toggleViewColumn,
+      title,
+      tableRef,
+    } = this.props;
 
-    const {search, downloadCsv, print, viewColumns, filterTable} = options.textLabels.toolbar;
-    const {showSearch} = this.state;
+    const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
+    const { showSearch } = this.state;
 
     return (
       <Toolbar className={classes.root} role={"toolbar"} aria-label={"Table Toolbar"}>
         <div className={classes.left}>
           {showSearch === true ? (
-            <MUIDataTableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options}/>
+            <MUIDataTableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options} />
           ) : (
-             <div className={classes.titleRoot} aria-hidden={"true"}>
-               <Typography variant="h6" className={classes.titleText}>
-                 {title}
-               </Typography>
-             </div>
-           )}
+            <div className={classes.titleRoot} aria-hidden={"true"}>
+              <Typography variant="h6" className={classes.titleText}>
+                {title}
+              </Typography>
+            </div>
+          )}
         </div>
         <div className={classes.actions}>
-
           {options.search && (
             <Tooltip title={search}>
               <IconButton
                 aria-label={search}
                 buttonRef={el => (this.searchButton = el)}
-                classes={{root: this.getActiveIcon(classes, "search")}}
+                classes={{ root: this.getActiveIcon(classes, "search") }}
                 onClick={this.setActiveIcon.bind(null, "search")}>
-                <SearchIcon/>
+                <SearchIcon />
               </IconButton>
             </Tooltip>
           )}
 
           {options.download && (
             <Tooltip title={downloadCsv}>
-              <IconButton aria-label={downloadCsv} classes={{root: classes.icon}} onClick={this.handleCSVDownload}>
-                <DownloadIcon/>
+              <IconButton aria-label={downloadCsv} classes={{ root: classes.icon }} onClick={this.handleCSVDownload}>
+                <DownloadIcon />
               </IconButton>
             </Tooltip>
           )}
@@ -219,8 +218,8 @@ class MUIDataTableToolbar extends React.Component {
               <span>
                 <ReactToPrint
                   trigger={() => (
-                    <IconButton aria-label={print} classes={{root: classes.icon}}>
-                      <PrintIcon/>
+                    <IconButton aria-label={print} classes={{ root: classes.icon }}>
+                      <PrintIcon />
                     </IconButton>
                   )}
                   content={() => this.props.tableRef()}
@@ -230,28 +229,25 @@ class MUIDataTableToolbar extends React.Component {
           )}
 
           {options.viewColumns && (
-            <MUIDataTablePopoverWrapper label={viewColumns}
-                                        tableRef={tableRef}
-                                        onClick={this.setActiveIcon.bind(null, "viewcolumns")}
-                                        buttonRoot={this.getActiveIcon(classes, "viewcolumns")}
-                                        icon={<ViewColumnIcon/>}
-                                        classes={classes}>
-              <MUIDataTableViewCol
-                  data={data}
-                  columns={columns}
-                  options={options}
-                  onColumnUpdate={toggleViewColumn}
-                />
+            <MUIDataTablePopoverWrapper
+              label={viewColumns}
+              tableRef={tableRef}
+              onClick={this.setActiveIcon.bind(null, "viewcolumns")}
+              buttonRoot={this.getActiveIcon(classes, "viewcolumns")}
+              icon={<ViewColumnIcon />}
+              classes={classes}>
+              <MUIDataTableViewCol data={data} columns={columns} options={options} onColumnUpdate={toggleViewColumn} />
             </MUIDataTablePopoverWrapper>
           )}
 
           {options.filter && (
-            <MUIDataTablePopoverWrapper label={filterTable}
-                                        tableRef={tableRef}
-                                        onClick={this.setActiveIcon.bind(null, "filter")}
-                                        buttonRoot={this.getActiveIcon(classes, "filter")}
-                                        icon={<FilterIcon/>}
-                                        classes={classes}>
+            <MUIDataTablePopoverWrapper
+              label={filterTable}
+              tableRef={tableRef}
+              onClick={this.setActiveIcon.bind(null, "filter")}
+              buttonRoot={this.getActiveIcon(classes, "filter")}
+              icon={<FilterIcon />}
+              classes={classes}>
               <MUIDataTableFilter
                 columns={columns}
                 options={options}
@@ -269,4 +265,4 @@ class MUIDataTableToolbar extends React.Component {
   }
 }
 
-export default styled(MUIDataTableToolbar)(defaultToolbarStyles, {name: "MUIDataTableToolbar"});
+export default styled(MUIDataTableToolbar)(defaultToolbarStyles, { name: "MUIDataTableToolbar" });

--- a/src/MUIPopover/MUIDataTablePopoverWrapper.js
+++ b/src/MUIPopover/MUIDataTablePopoverWrapper.js
@@ -10,20 +10,16 @@ class MUIDataTablePopoverWrapper extends React.PureComponent {
     super(props);
   }
   render() {
-    const {label, tableRef, onClick, icon, children} = this.props;
+    const { label, tableRef, onClick, icon, children } = this.props;
 
     return (
       <MUIPopover container={tableRef}>
         <MUIPopoverTarget>
-          <IconButton aria-label={label} onClick={onClick} >
-            <Tooltip title={label}>
-              {icon}
-            </Tooltip>
+          <IconButton aria-label={label} onClick={onClick}>
+            <Tooltip title={label}>{icon}</Tooltip>
           </IconButton>
         </MUIPopoverTarget>
-        <MUIPopoverContent>
-          {children}
-        </MUIPopoverContent>
+        <MUIPopoverContent>{children}</MUIPopoverContent>
       </MUIPopover>
     );
   }

--- a/src/MUIPopover/MUIDataTablePopoverWrapper.js
+++ b/src/MUIPopover/MUIDataTablePopoverWrapper.js
@@ -1,0 +1,32 @@
+import React from "react";
+import Tooltip from "@material-ui/core/Tooltip";
+import IconButton from "@material-ui/core/IconButton";
+import MUIPopover from "./MUIPopover";
+import MUIPopoverTarget from "./MUIPopoverTarget";
+import MUIPopoverContent from "./MUIPopoverContent";
+
+class MUIDataTablePopoverWrapper extends React.PureComponent {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    const {label, tableRef, onClick, icon, children} = this.props;
+
+    return (
+      <MUIPopover container={tableRef}>
+        <MUIPopoverTarget>
+          <IconButton aria-label={label} onClick={onClick} >
+            <Tooltip title={label}>
+              {icon}
+            </Tooltip>
+          </IconButton>
+        </MUIPopoverTarget>
+        <MUIPopoverContent>
+          {children}
+        </MUIPopoverContent>
+      </MUIPopover>
+    );
+  }
+}
+
+export default MUIDataTablePopoverWrapper;

--- a/src/MUIPopover/MUIPopover.js
+++ b/src/MUIPopover/MUIPopover.js
@@ -102,7 +102,6 @@ class MUIPopover extends React.Component {
             onClose={this.handleRequestClose}
             onExited={this.handleOnExit}
             anchorEl={this.anchorEl}
-            ref={el => this.popoverEl}
             anchorOrigin={anchorOriginSpecs}
             transformOrigin={transformOriginSpecs}
             {...providedProps}>


### PR DESCRIPTION
Fixes #252

This fixes an issue with re-rendering the complete Toolbar on data changes (filtering or column view changes) which resulted in the Filter Popover being closed and reopened when clicking on a filter or checking or unchecking a column in column view for the first time.

The issue was caused by the `tableRef` which was passed from the MuiDataTable instance down to the popover to be used as container.
This ref updated when the table was re-rendered and caused all components using it to also re-render.

As the prop was passed as a function which returned the ref, React considered the property changed on each re-render as the function would not be the same

see https://reactjs.org/docs/faq-functions.html

I also refactored  the popovers to be PureComponents and cleaned up the TableToolbar a bit, hope thats ok.