### PR TITLE
Export subcomponents

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,7 +52,8 @@ export default {
   ],
   output: {
     file: 'dist/index.js',
-    format: 'cjs'
+    format: 'cjs',
+    exports: 'named'
   },
   sourcemap: true
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,18 @@
-import MUIDataTable from './MUIDataTable';
-
-export default MUIDataTable;
+export { default } from './MUIDataTable';
+export { default as Popover } from './components/Popover';
+export { default as TableBodyCell } from './components/TableBodyCell';
+export { default as TableBody } from './components/TableBody';
+export { default as TableBodyRow } from './components/TableBodyRow';
+export { default as TableFilter } from './components/TableFilter';
+export { default as TableFilterList } from './components/TableFilterList';
+export { default as TableFooter } from './components/TableFooter';
+export { default as TableHeadCell } from './components/TableHeadCell';
+export { default as TableHead } from './components/TableHead';
+export { default as TableHeadRow } from './components/TableHeadRow';
+export { default as TablePagination } from './components/TablePagination';
+export { default as TableResize } from './components/TableResize';
+export { default as TableSearch } from './components/TableSearch';
+export { default as TableSelectCell } from './components/TableSelectCell';
+export { default as TableToolbar } from './components/TableToolbar';
+export { default as TableToolbarSelect } from './components/TableToolbarSelect';
+export { default as TableViewCol } from './components/TableViewCol';


### PR DESCRIPTION
This addresses #291.
Note that because this library is exported as a CommonJS module, this can break compatibility. Thoughts on introducing this?