### PR TITLE
Fix sorting when customSort doesn't sort inplace

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -851,9 +851,9 @@ class MUIDataTable extends React.Component {
 
     for (let i = 0; i < sortedData.length; i++) {
       const row = sortedData[i];
-      tableData.push(data[row.position]);
+      tableData.push(sortedData[row.position]);
       if (row.rowSelected) {
-        selectedRows.push({ index: i, dataIndex: data[row.position].index });
+        selectedRows.push({ index: i, dataIndex: sortedData[row.position].index });
       }
     }
 


### PR DESCRIPTION
When using the `customSort` prop, if the sort function provided doesn't sort `data` in place but returns a copy of `data` sorted, the original (unsorted) `data` is used to pick indexes... which results in no sorting happening in the table.

This PR ensures that the sorted list is used when reading indexes.