### PR TITLE
Allow the customization of noMatch in textLabels

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -47,7 +47,7 @@ class TableBody extends React.Component {
   buildRows() {
     const { data, page, rowsPerPage, count } = this.props;
 
-    if (this.props.options.serverSide) return data;
+    if (this.props.options.serverSide) return data.length ? data : null;
 
     let rows = [];
     const totalPages = Math.floor(count / rowsPerPage);


### PR DESCRIPTION
The noMatch in TableBody options can be useful to customize the loading/table-display when there are no results:

```
textLabels: {
    body: {
        noMatch: data.length === 0 ?
            <i className='fas fa-circle-notch fa-spin fa-lg'/> :
            'Sorry, there is no matching data to display'
    },
}
```

If, in the options, serverSide is set to true, this label gets ignored because it's not possible to pass null as data to the TableBody. So, **I couldn't find any means of customizing the label when in serverSide mode.**
This request intends to restore that ability and replicate the behaviour (as it happens without serverSide).