### PR TITLE
feature: Option to disable selection on certain rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The component accepts the following props:
 |**`textLabels `**|object||User provided labels to localize text
 |**`pagination`**|boolean|true|Enable/disable pagination
 |**`selectableRows`**|boolean|true|Enable/disable row selection
+|**`isRowSelectable`**|function||Enable/disable selection on certain rows with custom function. Returns true if not provided.  `function(dataIndex) => bool`
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`expandableRows`**|boolean|false|Enable/disable expandable rows
 |**`renderExpandableRow `**|function||Render expandable row. `function(rowData, rowMeta) => React Component`

--- a/examples/selectable-rows/index.js
+++ b/examples/selectable-rows/index.js
@@ -80,7 +80,7 @@ class Example extends React.Component {
       onRowClick: (rowData, rowState) => {
         console.log(rowData, rowState);
       },
-      isSelectable: (dataIndex) => {
+      isRowSelectable: (dataIndex) => {
         //prevents selection of row with title "Attorney"
         return data[dataIndex][1] != "Attorney";
       }

--- a/examples/selectable-rows/index.js
+++ b/examples/selectable-rows/index.js
@@ -79,6 +79,10 @@ class Example extends React.Component {
       },
       onRowClick: (rowData, rowState) => {
         console.log(rowData, rowState);
+      },
+      isSelectable: (dataIndex) => {
+        //prevents selection of row with title "Attorney"
+        return data[dataIndex][1] != "Attorney";
       }
     };
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -83,6 +83,7 @@ class MUIDataTable extends React.Component {
       onRowClick: PropTypes.func,
       resizableColumns: PropTypes.bool,
       selectableRows: PropTypes.bool,
+      isSelectable: PropTypes.func,
       serverSide: PropTypes.bool,
       onTableChange: PropTypes.func,
       caseSensitive: PropTypes.bool,
@@ -743,6 +744,7 @@ class MUIDataTable extends React.Component {
 
   selectRowUpdate = (type, value) => {
     if (type === 'head') {
+      const {isSelectable} = this.options; 
       this.setState(
         prevState => {
           const { displayData } = prevState;
@@ -752,9 +754,12 @@ class MUIDataTable extends React.Component {
               ? true
               : false;
 
-          let selectedRows = Array(displayData.length)
-            .fill()
-            .map((d, i) => ({ index: i, dataIndex: displayData[i].dataIndex }));
+            let selectedRows = displayData.reduce((arr, d, i) => {
+              const selected = isSelectable? isSelectable(displayData[i].dataIndex) : true;
+              selected && arr.push({ index: i, dataIndex: displayData[i].dataIndex });
+              return arr;
+            },[]);
+
 
           let newRows = [...prevState.selectedRows, ...selectedRows];
           let selectedMap = buildMap(newRows);

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -83,7 +83,7 @@ class MUIDataTable extends React.Component {
       onRowClick: PropTypes.func,
       resizableColumns: PropTypes.bool,
       selectableRows: PropTypes.bool,
-      isSelectable: PropTypes.func,
+      isRowSelectable: PropTypes.func,
       serverSide: PropTypes.bool,
       onTableChange: PropTypes.func,
       caseSensitive: PropTypes.bool,
@@ -744,7 +744,7 @@ class MUIDataTable extends React.Component {
 
   selectRowUpdate = (type, value) => {
     if (type === 'head') {
-      const {isSelectable} = this.options; 
+      const {isRowSelectable} = this.options; 
       this.setState(
         prevState => {
           const { displayData } = prevState;
@@ -755,7 +755,7 @@ class MUIDataTable extends React.Component {
               : false;
 
             let selectedRows = displayData.reduce((arr, d, i) => {
-              const selected = isSelectable? isSelectable(displayData[i].dataIndex) : true;
+              const selected = isRowSelectable? isRowSelectable(displayData[i].dataIndex) : true;
               selected && arr.push({ index: i, dataIndex: displayData[i].dataIndex });
               return arr;
             },[]);

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -94,8 +94,8 @@ class TableBody extends React.Component {
 
   isRowSelectable(dataIndex) {
     const { options } = this.props;
-    if (options.isSelectable) {
-      return options.isSelectable(dataIndex);
+    if (options.isRowSelectable) {
+      return options.isRowSelectable(dataIndex);
     }
     return true;
   }
@@ -133,7 +133,7 @@ class TableBody extends React.Component {
                     checked={this.isRowSelected(dataIndex)}
                     isExpandable={options.expandableRows}
                     isRowExpanded={this.isRowExpanded(dataIndex)}
-                    isSelectable={this.isRowSelectable(dataIndex)}
+                    isRowSelectable={this.isRowSelectable(dataIndex)}
                   />
                 )}
                 {row.map(

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -92,6 +92,14 @@ class TableBody extends React.Component {
     return expandedRows.lookup && expandedRows.lookup[dataIndex] ? true : false;
   }
 
+  isRowSelectable(dataIndex) {
+    const { options } = this.props;
+    if (options.isSelectable) {
+      return options.isSelectable(dataIndex);
+    }
+    return true;
+  }
+
   handleRowSelect = data => {
     this.props.selectRowUpdate('cell', data);
   };
@@ -125,6 +133,7 @@ class TableBody extends React.Component {
                     checked={this.isRowSelected(dataIndex)}
                     isExpandable={options.expandableRows}
                     isRowExpanded={this.isRowExpanded(dataIndex)}
+                    isSelectable={this.isRowSelectable(dataIndex)}
                   />
                 )}
                 {row.map(

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -49,7 +49,7 @@ class TableHead extends React.Component {
               isHeaderCell={true}
               isExpandable={options.expandableRows}
               fixedHeader={options.fixedHeader}
-              isSelectable={true}
+              isRowSelectable={true}
             />
           )}
           {columns.map(

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -49,6 +49,7 @@ class TableHead extends React.Component {
               isHeaderCell={true}
               isExpandable={options.expandableRows}
               fixedHeader={options.fixedHeader}
+              isSelectable={true}
             />
           )}
           {columns.map(

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -51,6 +51,8 @@ class TableSelectCell extends React.Component {
     onChange: PropTypes.func,
     /** Extend the style applied to components */
     classes: PropTypes.object,
+    /** Select cell disabled on/off */
+    isSelectable: PropTypes.bool
   };
 
   static defaultProps = {
@@ -60,7 +62,7 @@ class TableSelectCell extends React.Component {
   };
 
   render() {
-    const { classes, fixedHeader, isHeaderCell, isExpandable, isRowExpanded, onExpand, ...otherProps } = this.props;
+    const { classes, fixedHeader, isHeaderCell, isExpandable, isRowExpanded, onExpand, isSelectable, ...otherProps } = this.props;
 
     const cellClass = classNames({
       [classes.root]: true,
@@ -84,6 +86,7 @@ class TableSelectCell extends React.Component {
               checked: classes.checked,
               disabled: classes.disabled,
             }}
+            disabled={!isSelectable}
             {...otherProps}
           />
         </div>

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -52,7 +52,7 @@ class TableSelectCell extends React.Component {
     /** Extend the style applied to components */
     classes: PropTypes.object,
     /** Select cell disabled on/off */
-    isSelectable: PropTypes.bool
+    isRowSelectable: PropTypes.bool
   };
 
   static defaultProps = {
@@ -62,7 +62,7 @@ class TableSelectCell extends React.Component {
   };
 
   render() {
-    const { classes, fixedHeader, isHeaderCell, isExpandable, isRowExpanded, onExpand, isSelectable, ...otherProps } = this.props;
+    const { classes, fixedHeader, isHeaderCell, isExpandable, isRowExpanded, onExpand, isRowSelectable, ...otherProps } = this.props;
 
     const cellClass = classNames({
       [classes.root]: true,
@@ -86,7 +86,7 @@ class TableSelectCell extends React.Component {
               checked: classes.checked,
               disabled: classes.disabled,
             }}
-            disabled={!isSelectable}
+            disabled={!isRowSelectable}
             {...otherProps}
           />
         </div>


### PR DESCRIPTION
As mentioned in https://github.com/gregnb/mui-datatables/issues/172 by @brianpmaher 

with added following option in examples/selectable-rows/index.js
```
isSelectable: (dataIndex) => {
    //prevents selection of row with title "Attorney"
    return data[dataIndex][1] != "Attorney";
}
```
![screen shot 2019-01-04 at 8 39 32 am](https://user-images.githubusercontent.com/23511250/50699328-66a86d00-0ffc-11e9-86a7-99cede454584.jpg)
With select all clicked
![screen shot 2019-01-04 at 8 39 53 am](https://user-images.githubusercontent.com/23511250/50699335-6c05b780-0ffc-11e9-9137-34988474d594.jpg)
