### PR TITLE
Updating colors to work with the MUI themes.

### DIFF
--- a/examples/themes/index.js
+++ b/examples/themes/index.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MUIDataTable from '../../src/';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core';
+
+class Example extends React.Component {
+  render() {
+    const columns = [
+      {
+        name: 'Name',
+        options: {
+          filter: true,
+          filterList: ['Franky Miles'],
+          filterOptions: ['a', 'b', 'c', 'Business Analyst'],
+        },
+      },
+      {
+        name: 'Title',
+        options: {
+          filter: true,
+        },
+      },
+      {
+        name: 'Location',
+        options: {
+          filter: false,
+        },
+      },
+      {
+        name: 'Age',
+        options: {
+          filter: true,
+        },
+      },
+      {
+        name: 'Salary',
+        options: {
+          filter: true,
+          sort: false,
+        },
+      },
+    ];
+    const data = [
+      ['Gabby George', 'Business Analyst', 'Minneapolis', 30, 100000],
+      ['Business Analyst', 'Business Consultant', 'Dallas', 55, 200000],
+      ['Jaden Collins', 'Attorney', 'Santa Ana', 27, 500000],
+      ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, 50000],
+      ['Aaren Rose', 'Business Consultant', 'Toledo', 28, 75000],
+      ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, 94000],
+      ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, 210000],
+      ['Lane Wilson', 'Commercial Specialist', 'Omaha', 19, 65000],
+      ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, 77000],
+      ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, 135000],
+      ['Harper White', 'Attorney', 'Pittsburgh', 52, 420000],
+      ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, 150000],
+      ['Frankie Long', 'Industrial Analyst', 'Austin', 31, 170000],
+      ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, 90000],
+      ['Justice Mann', 'Business Consultant', 'Chicago', 24, 133000],
+      ['Addison Navarro', 'Business Management Analyst', 'New York', 50, 295000],
+      ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, 200000],
+      ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, 400000],
+      ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, 110000],
+      ['Danny Leon', 'Computer Scientist', 'Newark', 60, 220000],
+      ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, 180000],
+      ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, 99000],
+      ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, 90000],
+      ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, 140000],
+      ['Justice Mccarthy', 'Attorney', 'Tucson', 26, 330000],
+      ['Silver Carey', 'Computer Scientist', 'Memphis', 47, 250000],
+      ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, 190000],
+      ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, 80000],
+      ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, 45000],
+      ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, 142000],
+    ];
+
+    const options = {
+      filter: true,
+      selectableRows: true,
+      filterType: 'dropdown',
+      responsive: 'stacked',
+      rowsPerPage: 10,
+      page: 1,
+    };
+
+    return <MUIDataTable title={'ACME Employee list'} data={data} columns={columns} options={options} />;
+  }
+}
+
+const theme = createMuiTheme({
+  palette: { type: 'dark' },
+  typography: { useNextVariants: true },
+});
+
+const element = (
+  <MuiThemeProvider theme={theme}>
+    <Example />
+  </MuiThemeProvider>
+);
+
+ReactDOM.render(element, document.getElementById('app-root'));

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -19,6 +19,9 @@ import { buildMap, getCollatorComparator, sortCompare } from './utils';
 
 const defaultTableStyles = {
   root: {},
+  tableRoot: {
+    outline: 'none',
+  },
   responsiveScroll: {
     overflowX: 'auto',
     overflow: 'auto',
@@ -964,7 +967,7 @@ class MUIDataTable extends React.Component {
               setResizeable={fn => (this.setHeadResizeable = fn)}
             />
           )}
-          <MuiTable ref={el => (this.tableRef = el)} tabIndex={'0'} role={'grid'}>
+          <MuiTable ref={el => (this.tableRef = el)} tabIndex={'0'} role={'grid'} className={classes.tableRoot}>
             <caption className={classes.caption}>{title}</caption>
             <TableHead
               columns={columns}

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -11,7 +11,7 @@ const defaultBodyCellStyles = theme => ({
   cellStacked: {
     [theme.breakpoints.down('sm')]: {
       display: 'inline-block',
-      backgroundColor: '#FFF',
+      backgroundColor: theme.palette.background.paper,
       fontSize: '16px',
       height: '24px',
       width: 'calc(50% - 80px)',

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -14,8 +15,9 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { withStyles } from '@material-ui/core/styles';
 import { TextField } from '@material-ui/core';
 
-export const defaultFilterStyles = {
+export const defaultFilterStyles = theme => ({
   root: {
+    backgroundColor: theme.palette.background.default,
     padding: '16px 24px 16px 24px',
     fontFamily: 'Roboto',
   },
@@ -29,7 +31,7 @@ export const defaultFilterStyles = {
   title: {
     display: 'inline-block',
     marginLeft: '7px',
-    color: '#424242',
+    color: theme.palette.text.primary,
     fontSize: '14px',
     fontWeight: 500,
   },
@@ -40,16 +42,9 @@ export const defaultFilterStyles = {
     alignSelf: 'left',
   },
   resetLink: {
-    color: '#027cb5',
-    backgroundColor: '#FFF',
-    display: 'inline-block',
-    marginLeft: '24px',
+    marginLeft: '16px',
     fontSize: '12px',
     cursor: 'pointer',
-    border: 'none',
-    '&:hover': {
-      color: '#FF0000',
-    },
   },
   filtersSelected: {
     alignSelf: 'right',
@@ -64,7 +59,7 @@ export const defaultFilterStyles = {
     marginLeft: '7px',
     marginBottom: '8px',
     fontSize: '14px',
-    color: '#424242',
+    color: theme.palette.text.secondary,
     textAlign: 'left',
     fontWeight: 500,
   },
@@ -77,16 +72,15 @@ export const defaultFilterStyles = {
   checkboxFormControlLabel: {
     fontSize: '15px',
     marginLeft: '8px',
-    color: '#4a4a4a',
+    color: theme.palette.text.primary,
   },
   checkboxIcon: {
-    //color: "#027cb5",
     width: '32px',
     height: '32px',
   },
   checkbox: {
     '&$checked': {
-      color: '#027cB5',
+      color: theme.palette.primary.main,
     },
   },
   checked: {},
@@ -118,7 +112,7 @@ export const defaultFilterStyles = {
     marginRight: '24px',
     marginBottom: '24px',
   },
-};
+});
 
 class TableFilter extends React.Component {
   static propTypes = {
@@ -304,9 +298,14 @@ class TableFilter extends React.Component {
               })}>
               {textLabels.title}
             </Typography>
-            <button className={classes.resetLink} tabIndex={0} aria-label={textLabels.reset} onClick={onFilterReset}>
+            <Button
+              color="primary"
+              className={classes.resetLink}
+              tabIndex={0}
+              aria-label={textLabels.reset}
+              onClick={onFilterReset}>
               {textLabels.reset}
-            </button>
+            </Button>
           </div>
           <div className={classes.filtersSelected} />
         </div>

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -7,14 +7,14 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { withStyles } from '@material-ui/core/styles';
 import HelpIcon from '@material-ui/icons/Help';
 
-const defaultHeadCellStyles = {
+const defaultHeadCellStyles = theme => ({
   root: {},
   fixedHeader: {
     position: 'sticky',
     top: '0px',
     left: '0px',
     zIndex: 100,
-    backgroundColor: '#FFF',
+    backgroundColor: theme.palette.background.paper,
   },
   tooltip: {
     cursor: 'pointer',
@@ -35,14 +35,14 @@ const defaultHeadCellStyles = {
     height: '10px',
   },
   sortActive: {
-    color: 'rgba(0, 0, 0, 0.87)',
+    color: theme.palette.text.primary,
   },
   toolButton: {
     height: '10px',
     outline: 'none',
     cursor: 'pointer',
   },
-};
+});
 
 class TableHeadCell extends React.Component {
   static propTypes = {

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -6,12 +6,13 @@ import IconButton from '@material-ui/core/IconButton';
 import ClearIcon from '@material-ui/icons/Clear';
 import { withStyles } from '@material-ui/core/styles';
 
-const defaultSearchStyles = {
+const defaultSearchStyles = theme => ({
   main: {
     display: 'flex',
     flex: '1 0 auto',
   },
   searchIcon: {
+    color: theme.palette.text.secondary,
     marginTop: '10px',
     marginRight: '8px',
   },
@@ -20,10 +21,10 @@ const defaultSearchStyles = {
   },
   clearIcon: {
     '&:hover': {
-      color: '#FF0000',
+      color: theme.palette.error.main,
     },
   },
-};
+});
 
 class TableSearch extends React.Component {
   handleTextChange = event => {

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -30,11 +30,11 @@ const defaultSelectCellStyles = theme => ({
   },
   headerCell: {
     zIndex: 110,
-    backgroundColor: '#FFF',
+    backgroundColor: theme.palette.background.paper,
   },
   checkboxRoot: {
     '&$checked': {
-      color: '#027cb5',
+      color: theme.palette.primary.main,
     },
   },
   checked: {},

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -29,11 +29,11 @@ export const defaultToolbarStyles = (theme, props) => ({
   titleText: {},
   icon: {
     '&:hover': {
-      color: '#307BB0',
+      color: theme.palette.primary.main,
     },
   },
   iconActive: {
-    color: '#307BB0',
+    color: theme.palette.primary.main,
   },
   searchIcon: {
     display: 'inline-flex',

--- a/src/components/TableToolbarSelect.js
+++ b/src/components/TableToolbarSelect.js
@@ -7,9 +7,9 @@ import Typography from '@material-ui/core/Typography';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { withStyles } from '@material-ui/core/styles';
 
-const defaultToolbarSelectStyles = {
+const defaultToolbarSelectStyles = theme => ({
   root: {
-    backgroundColor: '#f7f7f7',
+    backgroundColor: theme.palette.background.default,
     flex: '1 1 100%',
     display: 'flex',
     height: '64px',
@@ -30,10 +30,8 @@ const defaultToolbarSelectStyles = {
     position: 'relative',
     transform: 'translateY(-50%)',
   },
-  deleteIcon: {
-    color: '#000',
-  },
-};
+  deleteIcon: {},
+});
 
 class TableToolbarSelect extends React.Component {
   static propTypes = {

--- a/src/components/TableViewCol.js
+++ b/src/components/TableViewCol.js
@@ -7,7 +7,7 @@ import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { withStyles } from '@material-ui/core/styles';
 
-export const defaultViewColStyles = {
+export const defaultViewColStyles = theme => ({
   root: {
     padding: '16px 24px 16px 24px',
     fontFamily: 'Roboto',
@@ -15,7 +15,7 @@ export const defaultViewColStyles = {
   title: {
     marginLeft: '-7px',
     fontSize: '14px',
-    color: '#424242',
+    color: theme.palette.text.secondary,
     textAlign: 'left',
     fontWeight: 500,
   },
@@ -30,16 +30,16 @@ export const defaultViewColStyles = {
   },
   checkboxRoot: {
     '&$checked': {
-      color: '#027cb5',
+      color: theme.palette.primary.main,
     },
   },
   checked: {},
   label: {
     fontSize: '15px',
     marginLeft: '8px',
-    color: '#4a4a4a',
+    color: theme.palette.text.primary,
   },
-};
+});
 
 class TableViewCol extends React.Component {
   static propTypes = {


### PR DESCRIPTION
This is essentially a copy of #300 but updated to work with the
new layout. It also replaces all colors I could find to be sure
they refrence the themes and still look good on both light and
dark themes.

See #300 for what the screenshots look like as they are
an example. Also, I added a new theme example that will render
dark by default.