### PR TITLE
Change title variant

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -146,7 +146,7 @@ class TableToolbar extends React.Component {
             <TableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options} />
           ) : (
             <div className={classes.titleRoot} aria-hidden={'true'}>
-              <Typography variant="h6" className={classes.titleText}>
+              <Typography variant="title" className={classes.titleText}>
                 {title}
               </Typography>
             </div>


### PR DESCRIPTION
h6 is no longer used on Typography variants: expected one of ["display4","display3","display2","display1","headline","title","subheading","body2","body1","caption","button"].