### PR TITLE
selectedRows text label typo fix

### DIFF
--- a/src/textLabels.js
+++ b/src/textLabels.js
@@ -29,7 +29,7 @@ const textLabels = {
     titleAria: "Show/Hide Table Columns",
   },
   selectedRows: {
-    text: "rows(s) selected",
+    text: "row(s) selected",
     delete: "Delete",
     deleteAria: "Delete Selected Rows",
   },


### PR DESCRIPTION
"rows(s)" -> "row(s)"