### PR TITLE
Do not force MUI to require new typography variants

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -153,10 +153,6 @@ class MUIDataTable extends React.Component {
     this.headCellRefs = {};
     this.setHeadResizeable = () => {};
     this.updateDividers = () => {};
-
-    if (window) {
-      window.__MUI_USE_NEXT_TYPOGRAPHY_VARIANTS__ = true;
-    }
   }
 
   componentWillMount() {


### PR DESCRIPTION
Applications, rather than mui-datatables, ought to be the ones
responsible for setting whether or not to use the new typography
variants. The flag does not need to be enabled in order to _use_ the new
variants. The flag mainly controls whether or not MUI will warn about
the usage of deprecated variants so applications can ensure they have
completely migrated away completely.

Resolves #398