### PR TITLE
event available in onCellClick

### DIFF
--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -30,10 +30,10 @@ const defaultBodyCellStyles = theme => ({
 });
 
 class TableBodyCell extends React.Component {
-  handleClick = () => {
+  handleClick = (event) => {
     const { colIndex, options, children, dataIndex, rowIndex } = this.props;
     if (options.onCellClick) {
-      options.onCellClick(children, { colIndex, rowIndex, dataIndex });
+      options.onCellClick(children, { colIndex, rowIndex, dataIndex, event });
     }
   };
 


### PR DESCRIPTION
Not sure if I should add event in the cellMeta or as a third argument...

(I would like to open a new tab when the user clicks the cell while pressing the ctrl key. That's why I need to access the MouseEvent)

Thank you