### PR TITLE
Fix Toolbar icon size

### DIFF
--- a/src/components/TableToolbarSelect.js
+++ b/src/components/TableToolbarSelect.js
@@ -16,6 +16,8 @@ const defaultToolbarSelectStyles = theme => ({
     position: 'relative',
     zIndex: 120,
     justifyContent: 'space-between',
+    paddingTop: theme.spacing.unit,
+    paddingBottom: theme.spacing.unit,
   },
   title: {
     paddingLeft: '26px',


### PR DESCRIPTION
Current icon on hover: 
![image](https://user-images.githubusercontent.com/1412853/53686647-2fb7b480-3d2a-11e9-868f-f5f6d677f13e.png)

After this pr:
![image](https://user-images.githubusercontent.com/1412853/53686656-49f19280-3d2a-11e9-8e7f-7fd4b0a983b8.png)

closes #364