### PR TITLE
FIX onRowClick being triggered by row (de)selection

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -104,6 +104,14 @@ class TableBody extends React.Component {
     this.props.selectRowUpdate('cell', data);
   };
 
+  handleRowClick = (row, data, event) => {
+    // don't trigger onRowClick if the event was actually a row selection
+    if (event.target.id && event.target.id.startsWith('MUIDataTableSelectCell')) {
+      return;
+    }
+    this.props.options.onRowClick && this.props.options.onRowClick(row, data, event);
+  };
+
   render() {
     const { classes, columns, toggleExpandRow, options } = this.props;
     const tableRows = this.buildRows();
@@ -118,7 +126,7 @@ class TableBody extends React.Component {
                 {...(options.setRowProps ? options.setRowProps(row, dataIndex) : {})}
                 options={options}
                 rowSelected={options.selectableRows ? this.isRowSelected(dataIndex) : false}
-                onClick={options.onRowClick ? options.onRowClick.bind(null, row, { rowIndex, dataIndex }) : null}
+                onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
                 id={'MUIDataTableBodyRow-' + dataIndex}>
                 <TableSelectCell
                   onChange={this.handleRowSelect.bind(null, {
@@ -135,6 +143,7 @@ class TableBody extends React.Component {
                   selectableOn={options.selectableRows}
                   isRowExpanded={this.isRowExpanded(dataIndex)}
                   isRowSelectable={this.isRowSelectable(dataIndex)}
+                  id={'MUIDataTableSelectCell-' + dataIndex}
                 />
                 {row.map(
                   (column, columnIndex) =>


### PR DESCRIPTION
At the moment, if you have an `onRowClick`-handler on a selectable row, the handler will be called when the user clicks the checkbox. I'm unsure if this is on purpose or not, but I have a hard time coming up with a scenario, where you want the click handler to be called on selection as well.

This PR fixes that, so the `onRowClick`-handler doesn't get called if the click happened on a select checkbox.

This is technically a breaking change for anyone that actually wants the onRowClick to be triggered on selection as well. If that is indeed a use case, maybe we should add a configuration of some kind, either like an option, or by returning a boolean from `onRowsSelected` that determines if the select should call `onRowClick` as well.

Right now, our temporary fix for this is:
```js
onRowClick={(row, _, event) => {
  if(event.target.type === 'checkbox'){
    return;
  }
  ...
}}
...
```