### PR TITLE
Allow contributors to npm install directly from git remote url

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "coverage:html": "cross-env NODE_ENV=test nyc check-coverage --lines 55 --reporter=html --reporter=text mocha --require babel-register test/*.js && nyc report --reporter=html",
     "prettier": "find src/ docs/ test/ -type f -name \"*.js\" ! -path \"*/.next/*\" | xargs prettier --write",
     "lint": "eslint src",
-    "build": "cross-env NODE_ENV=production npm run prettier && rollup -c"
+    "build": "cross-env NODE_ENV=production npm run prettier && rollup -c",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add a prepare script to package.json so contributors can run their fork directly from git, by adding the url of their fork in their main project's package.json using something like "mui-datatables": "https://github.com/benoitg/mui-datatables.git".  See https://docs.npmjs.com/cli/install for reference