### PR TITLE
Removed container prop on toolbar popovers to prevent body scroll

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -188,7 +188,6 @@ class TableToolbar extends React.Component {
           {options.viewColumns && (
             <Popover
               refExit={this.setActiveIcon.bind(null)}
-              container={tableRef}
               trigger={
                 <IconButton
                   aria-label={viewColumns}
@@ -207,7 +206,6 @@ class TableToolbar extends React.Component {
           {options.filter && (
             <Popover
               refExit={this.setActiveIcon.bind(null)}
-              container={tableRef}
               trigger={
                 <IconButton
                   aria-label={filterTable}


### PR DESCRIPTION
For issue https://github.com/gregnb/mui-datatables/issues/472

Removed the container prop for the filter and viewColumns buttons in the `TableToolbar.js` file. Without this, the container defaults to body and applies the `overflow: hidden` style to prevent the body from scrolling.

This matches the behavior of the rowsPerPage select menu.