### PR TITLE
Fixed the layout for the toolbar when adding custom buttons

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -19,10 +19,10 @@ import { createCSVDownload } from '../utils';
 export const defaultToolbarStyles = (theme, props) => ({
   root: {},
   left: {
-    flex: '1 1 55%',
+    flex: '0 0 auto',
   },
   actions: {
-    flex: '0 0 45%',
+    flex: '1 1 auto',
     textAlign: 'right',
   },
   titleRoot: {},


### PR DESCRIPTION
Just a small tweak to allow the toolbar to utilise the whitespace to the right of the title.  It will still wrap once all the whitespace has been used without affecting the title.