### PR TITLE
Disable table sorting for server side data

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -417,7 +417,7 @@ class MUIDataTable extends React.Component {
       }
     }
 
-    if (sortIndex !== null) {
+    if (!options.serverSide && sortIndex !== null) {
       const sortedData = this.sortTable(tableData, sortIndex, sortDirection);
       tableData = sortedData.data;
     }


### PR DESCRIPTION
Displays data in the same order as it comes from the API server.