### PR TITLE
Issue 442 - Column Resizing on Data Updates

### DIFF
--- a/examples/resizable-columns/index.js
+++ b/examples/resizable-columns/index.js
@@ -4,9 +4,35 @@ import MUIDataTable from "../../src/";
 
 class Example extends React.Component {
 
-  render() {
+  constructor(props) {
+    super(props);
 
-    const columns = ["Name", "Title", "Location"];
+    this.state = { counter: 1 };
+  }
+
+  // We update an arbitrary value here to test table resizing on state updates
+  update = () => {
+    let { counter } = this.state;
+    counter += 1;
+
+    this.setState({ counter });
+  };
+
+  render() {
+    const { counter } = this.state;
+
+    const columns = [
+      {
+        name: "Counter",
+        options: {
+          empty: true,
+          customBodyRender: value => <button onClick={this.update}>+</button>
+        }
+      },
+      "Name",
+      "Title",
+      "Location"
+    ];
 
     const data = [
       ["Gabby George", "Business Analyst", "Minneapolis"],
@@ -24,7 +50,7 @@ class Example extends React.Component {
     };
 
     return (
-      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+      <MUIDataTable title={"ACME Employee list" + " [" + counter + "]"} data={data} columns={columns} options={options} />
     );
 
   }

--- a/src/components/TableResize.js
+++ b/src/components/TableResize.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { findDOMNode } from 'react-dom';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -83,11 +82,10 @@ class TableResize extends React.Component {
 
   updateWidths = () => {
     let lastPosition = 0;
-    const { resizeCoords, tableWidth, tableHeight } = this.state;
+    const { resizeCoords, tableWidth } = this.state;
 
     Object.entries(resizeCoords).forEach(([key, item]) => {
       let newWidth = Number(((item.left - lastPosition) / tableWidth) * 100).toFixed(2);
-      item.percent = newWidth;
       lastPosition = item.left;
 
       const thCell = this.cellsRef[key];
@@ -117,7 +115,7 @@ class TableResize extends React.Component {
   };
 
   render() {
-    const { classes, options, rowSelected } = this.props;
+    const { classes } = this.props;
     const { id, isResize, resizeCoords, tableWidth, tableHeight } = this.state;
 
     return (

--- a/src/components/TableResize.js
+++ b/src/components/TableResize.js
@@ -26,6 +26,7 @@ class TableResize extends React.Component {
 
   state = {
     resizeCoords: {},
+    priorPosition: {},
     startPosition: 0,
     tableWidth: '100%',
     tableHeight: '100%',
@@ -41,7 +42,7 @@ class TableResize extends React.Component {
   componentDidMount() {
     this.windowWidth = null;
     this.props.setResizeable(this.setCellRefs);
-    this.props.updateDividers(() => this.setState({ updateCoords: true }, () => this.updateWidths()));
+    this.props.updateDividers(() => this.setState({ updateCoords: true }, () => this.updateWidths));
     window.addEventListener('resize', this.handleReize, false);
   }
 
@@ -58,8 +59,8 @@ class TableResize extends React.Component {
   setDividers = () => {
     const tableEl = findDOMNode(this.tableRef);
     const { width: tableWidth, height: tableHeight } = tableEl.getBoundingClientRect();
+    const { priorPosition, resizeCoords } = this.state;
 
-    let resizeCoords = {};
     let finalCells = Object.entries(this.cellsRef);
 
     finalCells.forEach(([key, item]) => {
@@ -67,13 +68,17 @@ class TableResize extends React.Component {
 
       const elRect = item.getBoundingClientRect();
       const elStyle = window.getComputedStyle(item, null);
+      const left = resizeCoords[key] !== undefined ? resizeCoords[key].left : undefined;
+      const oldLeft = priorPosition[key] || 0;
+      let newLeft = elRect.left + item.offsetWidth - parseInt(elStyle.paddingLeft) / 2;
 
-      resizeCoords[key] = {
-        left: elRect.left + item.offsetWidth - parseInt(elStyle.paddingLeft) / 2,
-      };
+      if (left === oldLeft) return;
+
+      resizeCoords[key] = { left: newLeft };
+      priorPosition[key] = newLeft;
     });
 
-    this.setState({ tableWidth, tableHeight, resizeCoords }, this.updateWidths());
+    this.setState({ tableWidth, tableHeight, resizeCoords, priorPosition }, this.updateWidths);
   };
 
   updateWidths = () => {
@@ -103,7 +108,7 @@ class TableResize extends React.Component {
       const curCoord = { ...resizeCoords[id], left: leftPos };
       const newResizeCoords = { ...resizeCoords, [id]: curCoord };
 
-      this.setState({ resizeCoords: newResizeCoords }, this.updateWidths());
+      this.setState({ resizeCoords: newResizeCoords }, this.updateWidths);
     }
   };
 

--- a/src/components/TableResize.js
+++ b/src/components/TableResize.js
@@ -31,7 +31,7 @@ class TableResize extends React.Component {
     tableHeight: '100%',
   };
 
-  handleReize = () => {
+  handleResize = () => {
     if (window.innerWidth !== this.windowWidth) {
       this.windowWidth = window.innerWidth;
       this.setDividers();
@@ -42,11 +42,11 @@ class TableResize extends React.Component {
     this.windowWidth = null;
     this.props.setResizeable(this.setCellRefs);
     this.props.updateDividers(() => this.setState({ updateCoords: true }, () => this.updateWidths));
-    window.addEventListener('resize', this.handleReize, false);
+    window.addEventListener('resize', this.handleResize, false);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleReize, false);
+    window.removeEventListener('resize', this.handleResize, false);
   }
 
   setCellRefs = (cellsRef, tableRef) => {


### PR DESCRIPTION
Addresses https://github.com/gregnb/mui-datatables/issues/442.

- Adds demonstration code to the resize example
- Fixes bug in resize by preventing resize calculations when there is no actual resizing (hence, vanilla state updates will not recalculate width)
- Add some minor code quality improvements (orphaned vars, misspelled function)

There is still a slight stutter sometimes when state is changed before or after a column resizing event. An alternative fix which addresses everything including the stutter would be to remove the `componentDidUpdate` here: https://github.com/gregnb/mui-datatables/blob/master/src/MUIDataTable.js#L183. It's a much simpler fix, but I assumed that this might have unintended consequences, so I went for the slightly more complex fix.