### PR TITLE
corrected "row(s) selected" from "rows(s) selected"

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ const options = {
       titleAria: "Show/Hide Table Columns",
     },
     selectedRows: {
-      text: "rows(s) selected",
+      text: "row(s) selected",
       delete: "Delete",
       deleteAria: "Delete Selected Rows",
     },


### PR DESCRIPTION
just a typo correction