### PR TITLE
 Fix sort ordering passed to sortTable function

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -622,7 +622,7 @@ class MUIDataTable extends React.Component {
       prevState => {
         let columns = cloneDeep(prevState.columns);
         let data = prevState.data;
-        const newOrder = columns[index].sortDirection === 'asc' ? 'desc' : 'asc';
+        const newOrder = columns[index].sortDirection === 'desc' ? 'asc' : 'desc';
 
         for (let pos = 0; pos < columns.length; pos++) {
           if (index !== pos) {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -399,7 +399,7 @@ class MUIDataTable extends React.Component {
 
       if (column.sortDirection !== null) {
         sortIndex = colIndex;
-        sortDirection = column.sortDirection === 'asc' ? 'desc' : 'asc';
+        sortDirection = column.sortDirection;
       }
     });
 
@@ -622,13 +622,13 @@ class MUIDataTable extends React.Component {
       prevState => {
         let columns = cloneDeep(prevState.columns);
         let data = prevState.data;
-        const order = prevState.columns[index].sortDirection;
+        const newOrder = columns[index].sortDirection === 'asc' ? 'desc' : 'asc';
 
         for (let pos = 0; pos < columns.length; pos++) {
           if (index !== pos) {
             columns[pos].sortDirection = null;
           } else {
-            columns[pos].sortDirection = columns[pos].sortDirection === 'asc' ? 'desc' : 'asc';
+            columns[pos].sortDirection = newOrder;
           }
         }
 
@@ -649,7 +649,7 @@ class MUIDataTable extends React.Component {
             selectedRows: prevState.selectedRows,
           };
         } else {
-          const sortedData = this.sortTable(data, index, order);
+          const sortedData = this.sortTable(data, index, newOrder);
 
           newState = {
             ...newState,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -508,7 +508,7 @@ class MUIDataTable extends React.Component {
 
     if (this.options.serverSide) {
       if (customSearch) {
-        console.warn("Server-side filtering is enabled, hence custom search will be ignored.");
+        console.warn('Server-side filtering is enabled, hence custom search will be ignored.');
       }
 
       return displayRow;

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -134,7 +134,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         sortDirection: null,
-        customBodyRender: renderState
+        customBodyRender: renderState,
       },
       {
         display: 'true',
@@ -442,7 +442,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         sortDirection: null,
-        customBodyRender: renderState
+        customBodyRender: renderState,
       },
       {
         name: 'Empty',
@@ -637,7 +637,7 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
   });
 
-  it("should skip client side filtering if server side filtering is enabled", () => {
+  it('should skip client side filtering if server side filtering is enabled', () => {
     const options = { filterType: 'textField', serverSide: true };
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);
     const table = shallowWrapper.dive();


### PR DESCRIPTION
Fixes two issues related to calculating the wrong order before passing it to sortTable function:
- When setting table data and finding a specific sort, don't toggle the existing sort order as this should be respected in this scenario.
- When toggling sort order, pass the new toggled order to sortTable instead of the original value.