### PR TITLE
Prevent closure of search bar  when any other toolbar buttons are clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # MUI-Datatables - Datatables for Material-UI
 
 [![Build Status](https://travis-ci.org/gregnb/mui-datatables.svg?branch=master)](https://travis-ci.org/gregnb/mui-datatables)
+[![NPM Downloads](https://img.shields.io/npm/dt/mui-datatables.svg?style=flat)](https://npmcharts.com/compare/mui-datatables?minimal=true)
 [![Coverage Status](https://coveralls.io/repos/github/gregnb/mui-datatables/badge.svg?branch=master)](https://coveralls.io/github/gregnb/mui-datatables?branch=master)
 [![dependencies Status](https://david-dm.org/gregnb/mui-datatables/status.svg)](https://david-dm.org/gregnb/mui-datatables)
 [![npm version](https://badge.fury.io/js/mui-datatables.svg)](https://badge.fury.io/js/mui-datatables)

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -33,7 +33,7 @@ class Homepage extends React.Component {
       <Layout>
         <div>
           <p>
-            MUI-Datatables is a data tables component built on <a href="https://www.material-ui.com">Material-UI V1</a>.
+            MUI-Datatables is a data tables component built on <a href="https://www.material-ui.com">Material-UI V3</a>.
             It comes with features like filtering, view/hide columns, search, export to CSV download, printing,
             selectable rows, pagination, and sorting. On top of the ability to customize styling on most views, there
             are two responsive modes "stacked" and "scroll" for mobile/tablet devices.

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -59,7 +59,7 @@ const TABLE_LOAD = {
 class MUIDataTable extends React.Component {
   static propTypes = {
     /** Title of the table */
-    title: PropTypes.string.isRequired,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     /** Data used to describe table */
     data: PropTypes.array.isRequired,
     /** Columns used to describe table */

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -19,6 +19,7 @@ import { buildMap, getCollatorComparator, sortCompare } from './utils';
 
 const defaultTableStyles = {
   root: {},
+  paper: {},
   tableRoot: {
     outline: 'none',
   },

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -170,7 +170,7 @@ class TableBody extends React.Component {
         ) : (
           <TableBodyRow options={options}>
             <TableBodyCell
-              colSpan={options.selectableRows ? visibleColCnt + 1 : visibleColCnt}
+              colSpan={options.selectableRows || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
               options={options}
               colIndex={0}
               rowIndex={0}>

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -230,7 +230,7 @@ class TableFilter extends React.Component {
           column.filter ? (
             <FormControl className={classes.textFieldFormControl} key={index}>
               <TextField
-                label={column.name}
+                label={column.label}
                 value={filterList[index].toString() || ''}
                 onChange={event => this.handleTextFieldChange(event, index)}
               />

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -144,6 +144,8 @@ class TableToolbar extends React.Component {
         <div className={classes.left}>
           {showSearch === true ? (
             <TableSearch onSearch={searchTextUpdate} onHide={this.hideSearch} options={options} />
+          ) : typeof title !== 'string' ? (
+            title
           ) : (
             <div className={classes.titleRoot} aria-hidden={'true'}>
               <Typography variant="h6" className={classes.titleText}>

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -61,6 +61,15 @@ describe('<TableToolbar />', function() {
     assert.strictEqual(actualResult.length, 5);
   });
 
+  it('should render a toolbar with custom title if title is not string', () => {
+    const title = <h1>custom title</h1>;
+    const mountWrapper = mount(
+      <TableToolbar title={title} columns={columns} data={data} options={options} setTableAction={setTableAction} />,
+    );
+    const actualResult = mountWrapper.find('h1');
+    assert.strictEqual(actualResult.length, 1);
+  });
+
   it('should render a toolbar with no search icon if option.search = false', () => {
     const newOptions = { ...options, search: false };
     const mountWrapper = mount(


### PR DESCRIPTION
Before this change, if user enters text in search bar and then clicks on filter icon (or any other icon on toolbar), the search text filed disappears. After this, the search bar does not disappear if it contains any search text.