### PR TITLE
Fix the colspan value when 'expandableRows' is set and data is empty

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -170,7 +170,7 @@ class TableBody extends React.Component {
         ) : (
           <TableBodyRow options={options}>
             <TableBodyCell
-              colSpan={options.selectableRows ? visibleColCnt + 1 : visibleColCnt}
+              colSpan={options.selectableRows || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
               options={options}
               colIndex={0}
               rowIndex={0}>


### PR DESCRIPTION
When the option **expandableRows** is set to true and **selectableRows** is set to false, the column span for the cell with the "noMatch" label is not correct. The correct value should be the *column count* plus 1 when setting to true either *expandableRows* or *selectableRows* options.