### PR TITLE
Fix for issue 274

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The component accepts the following props:
 |**`filterType `**|string|'dropdown'|Choice of filtering view. Options are "checkbox", "dropdown", "multiselect" or "textField"
 |**`textLabels `**|object||User provided labels to localize text
 |**`pagination`**|boolean|true|Enable/disable pagination
-|**`selectableRows`**|boolean|true|Enable/disable row selection
+|**`selectableRows`**|string|'multiple'|Numbers of rows that can be selected. Options are "multiple", "single", "none".
 |**`isRowSelectable`**|function||Enable/disable selection on certain rows with custom function. Returns true if not provided.  `function(dataIndex) => bool`
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`expandableRows`**|boolean|false|Enable/disable expandable rows

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -100,7 +100,10 @@ class MUIDataTable extends React.Component {
       customFooter: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
       onRowClick: PropTypes.func,
       resizableColumns: PropTypes.bool,
-      selectableRows: PropTypes.bool,
+      selectableRows: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.oneOf(['none', 'single', 'multiple']),
+      ]),
       isRowSelectable: PropTypes.func,
       serverSide: PropTypes.bool,
       onTableChange: PropTypes.func,
@@ -205,7 +208,7 @@ class MUIDataTable extends React.Component {
       textLabels,
       expandableRows: false,
       resizableColumns: false,
-      selectableRows: true,
+      selectableRows: 'multiple',
       caseSensitive: false,
       serverSide: false,
       rowHover: true,
@@ -226,7 +229,11 @@ class MUIDataTable extends React.Component {
       },
     };
 
-    this.options = merge(defaultOptions, props.options);
+    const extra = {};
+    if (typeof props.options.selectableRows === 'boolean') {
+      extra.selectableRows = props.options.selectableRows ? 'multiple' : 'none';
+    }
+    this.options = merge(defaultOptions, props.options, extra);
   }
 
   validateOptions(options) {
@@ -836,6 +843,12 @@ class MUIDataTable extends React.Component {
   };
 
   selectRowUpdate = (type, value) => {
+    // safety check
+    const { selectableRows } = this.options;
+    if (selectableRows === 'none') {
+      return;
+    }
+
     if (type === 'head') {
       const { isRowSelectable } = this.options;
       this.setState(
@@ -892,7 +905,10 @@ class MUIDataTable extends React.Component {
 
           if (rowPos >= 0) {
             selectedRows.splice(rowPos, 1);
+          } else if (selectableRows === 'single') {
+            selectedRows = [value];
           } else {
+            // multiple
             selectedRows.push(value);
           }
 

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -125,7 +125,7 @@ class TableBody extends React.Component {
               <TableBodyRow
                 {...(options.setRowProps ? options.setRowProps(row, dataIndex) : {})}
                 options={options}
-                rowSelected={options.selectableRows ? this.isRowSelected(dataIndex) : false}
+                rowSelected={options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false}
                 onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
                 id={'MUIDataTableBodyRow-' + dataIndex}>
                 <TableSelectCell
@@ -170,7 +170,7 @@ class TableBody extends React.Component {
         ) : (
           <TableBodyRow options={options}>
             <TableBodyCell
-              colSpan={options.selectableRows || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
+              colSpan={options.selectableRows !== 'none' || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
               options={options}
               colIndex={0}
               rowIndex={0}>

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -54,16 +54,15 @@ class TableSelectCell extends React.Component {
     /** Is expandable option enabled */
     expandableOn: PropTypes.bool,
     /** Is selectable option enabled */
-    selectableOn: PropTypes.bool,
+    selectableOn: PropTypes.string,
     /** Select cell disabled on/off */
-    isRowSelectable: PropTypes.bool,
   };
 
   static defaultProps = {
     isHeaderCell: false,
     isRowExpanded: false,
     expandableOn: false,
-    selectableOn: false,
+    selectableOn: 'none',
   };
 
   render() {
@@ -79,7 +78,7 @@ class TableSelectCell extends React.Component {
       ...otherProps
     } = this.props;
 
-    if (!expandableOn && !selectableOn) return false;
+    if (!expandableOn && selectableOn === 'none') return false;
 
     const cellClass = classNames({
       [classes.root]: true,
@@ -93,21 +92,29 @@ class TableSelectCell extends React.Component {
       [classes.expanded]: isRowExpanded,
     });
 
+    const renderCheckBox = () => {
+      if (isHeaderCell && selectableOn !== 'multiple') {
+        // only display the header checkbox for multiple selection.
+        return null;
+      }
+      return (
+        <Checkbox
+          classes={{
+            root: classes.checkboxRoot,
+            checked: classes.checked,
+            disabled: classes.disabled,
+          }}
+          disabled={!isRowSelectable}
+          {...otherProps}
+        />
+      );
+    };
+
     return (
       <TableCell className={cellClass} padding="checkbox">
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {expandableOn && <KeyboardArrowRight className={iconClass} onClick={onExpand} />}
-          {selectableOn && (
-            <Checkbox
-              classes={{
-                root: classes.checkboxRoot,
-                checked: classes.checked,
-                disabled: classes.disabled,
-              }}
-              disabled={!isRowSelectable}
-              {...otherProps}
-            />
-          )}
+          {selectableOn !== 'none' && renderCheckBox()}
         </div>
       </TableCell>
     );

--- a/src/components/TableToolbarSelect.js
+++ b/src/components/TableToolbarSelect.js
@@ -59,6 +59,10 @@ class TableToolbarSelect extends React.Component {
       throw new TypeError(`Array "selectedRows" must contain only numbers`);
     }
 
+    const { options } = this.props;
+    if (selectedRows.length > 1 && options.selectableRows === 'single') {
+      throw new Error('Can not select more than one row when "selectableRows" is "single"');
+    }
     this.props.selectRowUpdate('custom', selectedRows);
   };
 

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -522,15 +522,34 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(state.selectedRows.data, expectedResult);
   });
 
-  it('should update selectedRows when calling selectRowUpdate method with type=cell', () => {
-    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
+  it('If selectableRows=single, only the last cell must be selected when calling selectRowUpdate method with type=cell.', () => {
+    const options = { selectableRows: 'single' };
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />).dive();
     const instance = shallowWrapper.instance();
 
-    instance.selectRowUpdate('cell', 0);
+    instance.selectRowUpdate('cell', {index: 0, dataIndex: 0});
+    instance.selectRowUpdate('cell', {index: 1, dataIndex: 1});
     shallowWrapper.update();
 
     const state = shallowWrapper.state();
-    assert.deepEqual(state.selectedRows.data, [0]);
+    assert.deepEqual(state.selectedRows.data, [{index: 1, dataIndex: 1}]);
+  });
+
+  it('If selectableRows=multiple, multiple cells can be selected when calling selectRowUpdate method with type=cell.', () => {
+    const options = { selectableRows: 'multiple' };
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />).dive();
+    const instance = shallowWrapper.instance();
+
+    instance.selectRowUpdate('cell', {index: 0, dataIndex: 0});
+    instance.selectRowUpdate('cell', {index: 1, dataIndex: 1});
+    shallowWrapper.update();
+
+    const expectedResult = [
+      {index: 0, dataIndex: 0},
+      {index: 1, dataIndex: 1},
+    ];
+    const state = shallowWrapper.state();
+    assert.deepEqual(state.selectedRows.data, expectedResult);
   });
 
   it('should update selectedRows when calling selectRowUpdate method with type=custom', () => {

--- a/test/MUIDataTableBody.test.js
+++ b/test/MUIDataTableBody.test.js
@@ -40,8 +40,8 @@ describe('<TableBody />', function() {
     ];
   });
 
-  it('should render a table body with no selectable cells if selectableRows = false', () => {
-    const options = { selectableRows: false };
+  it('should render a table body with no selectable cells if selectableRows = none', () => {
+    const options = { selectableRows: 'none' };
     const selectRowUpdate = () => {};
     const toggleExpandRow = () => {};
 

--- a/test/MUIDataTableHead.test.js
+++ b/test/MUIDataTableHead.test.js
@@ -4,6 +4,7 @@ import { mount, shallow } from 'enzyme';
 import { assert, expect, should } from 'chai';
 import TableHead from '../src/components/TableHead';
 import TableHeadCell from '../src/components/TableHeadCell';
+import Checkbox from '@material-ui/core/Checkbox';
 import Tooltip from '@material-ui/core/Tooltip';
 
 describe('<TableHead />', function() {
@@ -114,5 +115,53 @@ describe('<TableHead />', function() {
 
     let state = shallowWrapper.state();
     assert.strictEqual(rowSelectUpdate.callCount, 1);
+  });
+
+  it('should render a table head with checkbox if selectableRows = multiple', () => {
+    const options = { selectableRows: 'multiple' };
+
+    const mountWrapper = mount(
+      <TableHead
+        columns={columns}
+        options={options}
+        setCellRef={() => {}}
+        handleHeadUpdateRef={handleHeadUpdateRef}
+      />,
+    );
+
+    const actualResult = mountWrapper.find(Checkbox);
+    assert.strictEqual(actualResult.length, 1);
+  });
+
+  it('should render a table head with no checkbox if selectableRows = single', () => {
+    const options = { selectableRows: 'single' };
+
+    const mountWrapper = mount(
+      <TableHead
+        columns={columns}
+        options={options}
+        setCellRef={() => {}}
+        handleHeadUpdateRef={handleHeadUpdateRef}
+      />,
+    );
+
+    const actualResult = mountWrapper.find(Checkbox);
+    assert.strictEqual(actualResult.length, 0);
+  });
+
+  it('should render a table head with no checkbox if selectableRows = none', () => {
+    const options = { selectableRows: 'none' };
+
+    const mountWrapper = mount(
+      <TableHead
+        columns={columns}
+        options={options}
+        setCellRef={() => {}}
+        handleHeadUpdateRef={handleHeadUpdateRef}
+      />,
+    );
+
+    const actualResult = mountWrapper.find(Checkbox);
+    assert.strictEqual(actualResult.length, 0);
   });
 });


### PR DESCRIPTION
Fixes issue #274 extending the default behaviour of `selectableRows` so it supports one of `single`, `multiple` or `none`.

The checkbox in the header section will be only displayed when `selectableRows == 'multiple'`.
In the case of `single` selection, the checkboxes will be kept next to the rows, but no in the header. Also clicking any other row different than the selected one will change the selection.
