### PR TITLE
Fix for Issue 258 (Do not render toolbar when all options are missing)

### DIFF
--- a/examples/simple-no-toolbar/index.js
+++ b/examples/simple-no-toolbar/index.js
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import MUIDataTable from "../../src/";
+
+class Example extends React.Component {
+  render() {
+    const columns = ["Name", "Title", "Location"];
+
+    const data = [
+      ["Gabby George", "Business Analyst", "Minneapolis"],
+      ["Aiden Lloyd", "Business Consultant", "Dallas"],
+      ["Jaden Collins", "Attorney", "Santa Ana"],
+      ["Franky Rees", "Business Analyst", "St. Petersburg"],
+      ["Aaren Rose", null, "Toledo"]
+    ];
+
+    const options = {
+      filter: false,
+      search: false,
+      print: false,
+      download: false,
+      viewColumns: false,
+      customToolbar: null,
+      responsive: 'stacked'
+    };
+
+    return (
+      <MUIDataTable title={""} data={data} columns={columns} options={options} />
+    );
+  }
+}
+
+ReactDOM.render(<Example />, document.getElementById("app-root"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,6 +6593,11 @@
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
       "dev": true
     },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6608,6 +6613,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,10 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.find": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
+    "lodash.isundefined": "^3.0.1",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.0",
     "prop-types": "^15.6.0",

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -13,6 +13,8 @@ import classnames from 'classnames';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import isEqual from 'lodash.isequal';
+import find from 'lodash.find';
+import isUndefined from 'lodash.isUndefined';
 import textLabels from './textLabels';
 import { withStyles } from '@material-ui/core/styles';
 import { buildMap, getCollatorComparator, sortCompare } from './utils';
@@ -55,6 +57,23 @@ const defaultTableStyles = {
 const TABLE_LOAD = {
   INITIAL: 1,
   UPDATE: 2,
+};
+
+// Populate this list with anything that might render in the toolbar to determine if we hide the toolbar
+const TOOLBAR_ITEMS = [
+  'title',
+  'filter',
+  'search',
+  'print',
+  'download',
+  'viewColumns',
+  'customToolbar'
+];
+
+const hasToolbarItem = (options, title) => {
+  options.title = title;
+
+  return !isUndefined(find(TOOLBAR_ITEMS, i => options[i]));
 };
 
 class MUIDataTable extends React.Component {
@@ -991,6 +1010,7 @@ class MUIDataTable extends React.Component {
 
     const rowCount = this.options.count || displayData.length;
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
+    const showToolbar = hasToolbarItem(this.options, title);
 
     return (
       <Paper
@@ -1005,7 +1025,7 @@ class MUIDataTable extends React.Component {
             displayData={displayData}
             selectRowUpdate={this.selectRowUpdate}
           />
-        ) : (
+        ) : showToolbar && (
           <TableToolbar
             columns={columns}
             displayData={displayData}

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -14,7 +14,7 @@ import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import isEqual from 'lodash.isequal';
 import find from 'lodash.find';
-import isUndefined from 'lodash.isUndefined';
+import isUndefined from 'lodash.isundefined';
 import textLabels from './textLabels';
 import { withStyles } from '@material-ui/core/styles';
 import { buildMap, getCollatorComparator, sortCompare } from './utils';

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -5,6 +5,7 @@ import { assert, expect } from 'chai';
 import MUIDataTable from '../src/MUIDataTable';
 import TableFilterList from '../src/components/TableFilterList';
 import TablePagination from '../src/components/TablePagination';
+import TableToolbar from '../src/components/TableToolbar';
 import textLabels from '../src/textLabels';
 import Chip from '@material-ui/core/Chip';
 import Cities from '../examples/component/cities';
@@ -264,6 +265,20 @@ describe('<MUIDataTable />', function() {
 
     const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
     const actualResult = mountWrapper.find(TablePagination);
+    assert.lengthOf(actualResult, 0);
+  });
+
+  it('should not render toolbar when all its displayable items are missing', () => {
+    const options = {
+      filter: false,
+      search: false,
+      print: false,
+      download: false,
+      viewColumns: false
+    };
+
+    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+    const actualResult = mountWrapper.find(TableToolbar);
     assert.lengthOf(actualResult, 0);
   });
 


### PR DESCRIPTION
Prevents the rendering of the toolbar when the all of the toolbar display items are missing, including:

- filter
- search
- print
- download
- viewColumns
- customToolbar
- title

Also adds a test case for this scenario, as well as an example on the example page.