### PR TITLE
Issue 565 Sort Order Swapped

### DIFF
--- a/examples/customize-columns/index.js
+++ b/examples/customize-columns/index.js
@@ -19,6 +19,7 @@ class Example extends React.Component {
         name: "Title",
         options: {
           filter: true,
+          sortDirection: 'asc'
         }
       },
       {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ function sortCompare(order) {
     if (b.data === null) b.data = '';
     return (
       (typeof a.data.localeCompare === 'function' ? a.data.localeCompare(b.data) : a.data - b.data) *
-      (order === 'asc' ? -1 : 1)
+      (order === 'asc' ? 1 : -1)
     );
   };
 }

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -380,10 +380,29 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
   });
 
-  it('should sort provided column when calling toggleSortColum method', () => {
+  it('should sort provided column in descending order when calling toggleSortColum method for the first time', () => {
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
     const instance = shallowWrapper.instance();
 
+    instance.toggleSortColumn(0);
+    shallowWrapper.update();
+    const state = shallowWrapper.state();
+
+    const expectedResult = JSON.stringify([
+      { data: ['Walsh, John', 'Test Corp', renderCities('Hartford', { rowIndex: 0 }), null, undefined], dataIndex: 1 },
+      { data: ['James, Joe', 'Test Corp', renderCities('Yonkers', { rowIndex: 1 }), 'NY', undefined], dataIndex: 0 },
+      { data: ['Houston, James', 'Test Corp', renderCities('Dallas', { rowIndex: 2 }), 'TX', undefined], dataIndex: 3 },
+      { data: ['Herm, Bob', 'Test Corp', renderCities('Tampa', { rowIndex: 3 }), 'FL', undefined], dataIndex: 2 },
+    ]);
+
+    assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
+  });
+
+  it('should sort provided column in ascending order when calling toggleSortColum method twice', () => {
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
+    const instance = shallowWrapper.instance();
+
+    instance.toggleSortColumn(0);
     instance.toggleSortColumn(0);
     shallowWrapper.update();
     const state = shallowWrapper.state();


### PR DESCRIPTION
Fixes https://github.com/gregnb/mui-datatables/pull/570.

After the sort order was changed here https://github.com/gregnb/mui-datatables/pull/508/files, the ordering was swapped. We restore it by switching the values in the comparator.

Also updates the sort test and adds another one for the opposing sort direction.