### PR TITLE
Fix index for rowsSelected

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -437,7 +437,16 @@ class MUIDataTable extends React.Component {
     if (TABLE_LOAD.INITIAL) {
       if (options.rowsSelected && options.rowsSelected.length) {
         options.rowsSelected.forEach(row => {
-          selectedRowsData.data.push({ index: row, dataIndex: row });
+          let rowPos = row;
+
+          for (let cIndex = 0; cIndex < this.state.displayData.length; cIndex++) {
+            if (this.state.displayData[cIndex].dataIndex === dataIndex) {
+              rowPos = cIndex;
+              break;
+            }
+          }
+
+          selectedRowsData.data.push({ index: rowPos, dataIndex: row });
           selectedRowsData.lookup[row] = true;
         });
       }


### PR DESCRIPTION
This will fix index for rowsSelected. When rowsSelected are added to options, it should add array of { index: index, dataIndex: row } to selectedRowsData. However, the index could NOT be same as dataIndex, e.g., users filter data first and set rowsSelected. The PR fix the issue #514 