### PR TITLE
fix issue 514 index for rowsSelected option

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -437,7 +437,16 @@ class MUIDataTable extends React.Component {
     if (TABLE_LOAD.INITIAL) {
       if (options.rowsSelected && options.rowsSelected.length) {
         options.rowsSelected.forEach(row => {
-          selectedRowsData.data.push({ index: row, dataIndex: row });
+          let rowPos = row;
+
+          for (let cIndex = 0; cIndex < this.state.displayData.length; cIndex++) {
+            if (this.state.displayData[cIndex].dataIndex === row) {
+              rowPos = cIndex;
+              break;
+            }
+          }
+
+          selectedRowsData.data.push({ index: rowPos, dataIndex: row });
           selectedRowsData.lookup[row] = true;
         });
       }


### PR DESCRIPTION
This PR fix index for rowsSelected option. When rowsSelected are added in option, { index: rowPos, dataIndex: row } are added into selectedRowsData. However, the index could not be same as dataIndex, e.g, users filter data first and set rowsSelected. The PR fix #514 