### PR TITLE
Issue 213 Clarify customHeadRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The component accepts the following props:
 |:--:|:-----|:-----|
 |**`title`**|array|Title used to caption table
 |**`columns`**|array|Columns used to describe table. Must be either an array of simple strings or objects describing a column
-|**`data`**|array|Data used to describe table. Must be an array containing objects. (Arrays containing just strings or numbers also supported)
+|**`data`**|array|Data used to describe table. Must be an array containing objects. (Arrays containing just strings or numbers also supported) 
 |**`options`**|object|Options used to describe table
 
 #### Options:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The component accepts the following props:
 |:--:|:-----|:-----|
 |**`title`**|array|Title used to caption table
 |**`columns`**|array|Columns used to describe table. Must be either an array of simple strings or objects describing a column
-|**`data`**|array|Data used to describe table. Must be an array containing objects. (Arrays containing just strings or numbers also supported) 
+|**`data`**|array|Data used to describe table. Must be an array containing objects. (Arrays containing just strings or numbers also supported)
 |**`options`**|object|Options used to describe table
 
 #### Options:
@@ -219,7 +219,7 @@ const columns = [
 |**`print`**|boolean|true|Display column when printing
 |**`download`**|boolean|true|Display column in CSV download file
 |**`hint`**|string||Display hint icon with string as tooltip on hover.
-|**`customHeadRender`**|function||Function that returns a string or React component. Used as display for column header. `function(value, tableMeta, updateValue) => string`&#124;
+|**`customHeadRender`**|function||Function that returns a string or React component. Used as display for column header. `function(columnMeta, handleToggleColumn) => string`&#124;` React Component`
 |**`customBodyRender`**|function||Function that returns a string or React component. Used as display data within all table cells of a given column. `function(value, tableMeta, updateValue) => string`&#124;` React Component` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/component/index.js)
 |**`setCellProps`**|function||Is called for each cell and allows to return custom props for this cell based on its data. `function(cellValue: string, rowIndex: number, columnIndex: number) => object`
 
@@ -227,11 +227,20 @@ const columns = [
 
 ```js
 function(columnMeta: {
+  customHeadRender: func,
   display: enum('true', 'false', 'excluded'),
   filter: bool,
   sort: bool,
   sortDirection: bool,
-}, updateDirection: function)
+  download: bool,
+  empty: bool,
+  index: number,
+  label: string,
+  name: string,
+  print: bool,
+  searchable: bool,
+  viewColumns: bool
+}, handleToggleColumn: function(columnIndex))
 ```
 
 

--- a/examples/customize-columns/index.js
+++ b/examples/customize-columns/index.js
@@ -26,6 +26,11 @@ class Example extends React.Component {
         name: "Location",
         options: {
           filter: false,
+          customHeadRender: (columnMeta, updateDirection) => (
+            <th key={2} onClick={() => updateDirection(2)} style={{ cursor: 'pointer' }}>
+              {columnMeta.name}
+            </th>
+          )
         }
       },
       {

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -21,6 +21,7 @@ describe('<MUIDataTable />', function() {
   );
   let renderName = value => value.split(' ')[1] + ', ' + value.split(' ')[0];
   let renderState = value => value;
+  let renderHead = columnMeta => columnMeta.name + 's';
   let defaultRenderCustomFilterList = f => f;
   let renderCustomFilterList = f => `Name: ${f}`;
 
@@ -29,7 +30,7 @@ describe('<MUIDataTable />', function() {
       { name: 'Name', options: { customBodyRender: renderName, customFilterListRender: renderCustomFilterList } },
       'Company',
       { name: 'City', label: 'City Label', options: { customBodyRender: renderCities, filterType: 'textField' } },
-      { name: 'State', options: { customBodyRender: renderState, filterType: 'multiselect' } },
+      { name: 'State', options: { customBodyRender: renderState, filterType: 'multiselect', customHeadRender: renderHead } },
       { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
     ];
     data = [
@@ -141,6 +142,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         sortDirection: null,
         customBodyRender: renderState,
+        customHeadRender: renderHead,
       },
       {
         display: 'true',
@@ -511,6 +513,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         sortDirection: null,
         customBodyRender: renderState,
+        customHeadRender: renderHead,
       },
       {
         name: 'Empty',

--- a/test/MUIDataTableHead.test.js
+++ b/test/MUIDataTableHead.test.js
@@ -16,7 +16,18 @@ describe('<TableHead />', function() {
       { name: 'First Name', label: 'First Name', display: 'true', sort: null },
       { name: 'Company', label: 'Company', display: 'true', sort: null },
       { name: 'City', label: 'City Label', display: 'true', sort: null },
-      { name: 'State', label: 'State', display: 'true', sort: null },
+      {
+        name: 'State',
+        label: 'State',
+        display: 'true',
+        options: { fixedHeader: true },
+        customHeadRender: columnMeta => (
+          <TableHeadCell {...columnMeta}>
+            {columnMeta.name + 's'}
+          </TableHeadCell>
+        ),
+        sort: null
+      },
     ];
 
     handleHeadUpdateRef = () => {};
@@ -53,7 +64,7 @@ describe('<TableHead />', function() {
       />,
     );
     const labels = mountWrapper.find(TableHeadCell).map(n => n.text());
-    assert.deepEqual(labels, ['First Name', 'Company', 'City Label', 'State']);
+    assert.deepEqual(labels, ['First Name', 'Company', 'City Label', 'States']);
   });
 
   it('should render a table head with no cells', () => {


### PR DESCRIPTION
Should help to close https://github.com/gregnb/mui-datatables/issues/213.

`customHeadRender` actually works properly as of `2.0.0-beta.59`, so the issue is out of date, however, I also noticed that the documentation around this feature was out of date, and could have been leading to confusion, so I did the following:

- Updated the documentation
- Added the option to example code
- Added testing around `customHeadRender` to help prevent future regressions