### PR TITLE
Allow select boxes and expandable row icons in responsive view

### DIFF
--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -9,7 +9,7 @@ import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 const defaultSelectCellStyles = theme => ({
   root: {
     [theme.breakpoints.down('sm')]: {
-      display: 'none',
+      backgroundColor: theme.palette.background.paper,
     },
   },
   fixedHeader: {


### PR DESCRIPTION
Fixes https://github.com/gregnb/mui-datatables/issues/525.

The issue looked like a bug to me, but I thought it also might have been your intent to hide expandable icons and select boxes on responsive breakpoints, so I'm curious what you think. It does take up valuable space, but it also seems like it could be confusing UX to hide the options without any way to reinstate/toggle them back on (other than a wider viewport).

548px:

![image](https://user-images.githubusercontent.com/1779564/56843264-6a425700-686c-11e9-9505-8c819711a65d.png)

![image](https://user-images.githubusercontent.com/1779564/56843273-7b8b6380-686c-11e9-94f2-f561d9eef91a.png)