### PR TITLE
Fix toolbar trash icon button height

### DIFF
--- a/src/components/TableToolbarSelect.js
+++ b/src/components/TableToolbarSelect.js
@@ -27,6 +27,7 @@ const defaultToolbarSelectStyles = theme => ({
   },
   iconButton: {
     marginRight: '24px',
+    height: '48px',
     top: '50%',
     display: 'block',
     position: 'relative',


### PR DESCRIPTION
Fixes improper height for icon as demonstrated when hovering (notice the icon all the way on the right).

Broken:
![Capture_broken](https://user-images.githubusercontent.com/1779564/56992464-2307df00-6b68-11e9-97f2-4e32e13555e4.PNG)

Fixed:
![Capture_fix](https://user-images.githubusercontent.com/1779564/56992477-2733fc80-6b68-11e9-8538-77ff5640a6ae.PNG)
