### PR TITLE
customRowRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The component accepts the following props:
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
 |**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage) => string`&#124;` React Component`
-|**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender({ data, dataIndex }, rowIndex) => React Component`
+|**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`elevation`**|number|4|Shadow depth applied to Paper component

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The component accepts the following props:
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
 |**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage) => string`&#124;` React Component`
+|**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender({ data, dataIndex }, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`elevation`**|number|4|Shadow depth applied to Paper component

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import ReactDOM from "react-dom";
-import MuiDatatable from "../../src/";
+import MuiDataTable from "../../src/";
 
 function YourCustomRowComponent(props) {
   const { name, cardNumber, cvc, expiry } = props;
@@ -48,7 +48,7 @@ const creditCards = [
 
 function Example() {
   return (
-    <MuiDatatable
+    <MuiDataTable
       title="Cards"
       data={creditCards}
       columns={[

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -5,7 +5,8 @@
 */
 
 import React from 'react';
-import MuiDatatable from "mui-datatables";
+import ReactDOM from "react-dom";
+import MuiDatatable from "../../src/";
 
 function YourCustomRowComponent(props) {
   const { name, cardNumber, cvc, expiry } = props;

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -1,0 +1,95 @@
+/*
+  See another example of how to use `customRowRender` at
+  https://github.com/Skn0tt/mui-datatables-responsive-demo
+  https://mui-datatables-responsive-demo.skn0tt.now.sh
+*/
+
+import React from 'react';
+import MuiDatatable from "mui-datatables";
+
+function YourCustomRowComponent(props) {
+  const { name, cardNumber, cvc, expiry } = props;
+
+  return (
+    <div>
+      <h1>
+        {name}
+      </h1>
+      <p>
+        Number: {cardNumber} <br/>
+        CVC: {cvc} <br/>
+        expiry: {expiry}
+      </p>
+    </div>
+  );
+}
+
+const creditCards = [
+  {
+    name: "Tom Tallis",
+    cardNumber: "5500005555555559",
+    cvc: "582",
+    expiry: "02/24"
+  },
+  {
+    name: "Rich Harris",
+    cardNumber: "4444444444444448",
+    cvc: "172",
+    expiry: "03/22"
+  },
+  {
+    name: "Moby Dixon",
+    cardNumber: "3566003566003566",
+    cvc: "230",
+    expiry: "12/25"
+  }
+];
+
+function Example() {
+  return (
+    <MuiDatatable
+      title="Cards"
+      data={creditCards}
+      columns={[
+        {
+          name: "name",
+          label: "Name",
+        },
+        {
+          name: "cardNumber",
+          label: "Card Number"
+        },
+        {
+          name: "cvc",
+          label: "CVC"
+        },
+        {
+          name: "expiry",
+          label: "Expiry"
+        },
+      ]}
+      options={{
+        selectableRows: "none",
+        responsive: "scroll",
+        customRowRender: ({ data }) => {
+          const [ name, cardNumber, cvc, expiry ] = data;
+          
+          return (
+            <tr key={cardNumber}>
+              <td colSpan={4} style={{ paddingTop: "10px"}}>
+                <YourCustomRowComponent
+                  name={name}
+                  cardNumber={cardNumber}
+                  cvc={cvc}
+                  expiry={expiry}
+                />
+              </td>
+            </tr>
+          );
+        },
+      }}
+    />
+  );
+}
+
+ReactDOM.render(<Example />, document.getElementById("app-root"));

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -72,7 +72,7 @@ function Example() {
       options={{
         selectableRows: "none",
         responsive: "scroll",
-        customRowRender: ({ data }) => {
+        customRowRender: data => {
           const [ name, cardNumber, cvc, expiry ] = data;
           
           return (

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default {
     }),
     uglify({
       compress: {
-        warnings: false,
+        // warnings: false,
         conditionals: true,
         unused: true,
         comparisons: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default {
     }),
     uglify({
       compress: {
-        // warnings: false,
+        warnings: false,
         conditionals: true,
         unused: true,
         comparisons: true,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -111,6 +111,7 @@ class MUIDataTable extends React.Component {
       customToolbar: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
       customToolbarSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
       customFooter: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
+      customRowRender: PropTypes.func,
       onRowClick: PropTypes.func,
       resizableColumns: PropTypes.bool,
       selectableRows: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['none', 'single', 'multiple'])]),

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -121,11 +121,11 @@ class TableBody extends React.Component {
       <MuiTableBody>
         {tableRows && tableRows.length > 0 ? (
           tableRows.map((data, rowIndex) => {
-            if (options.customRowRender) {
-              return options.customRowRender(data, rowIndex);
-            }
-
             const { data: row, dataIndex } = data;
+
+            if (options.customRowRender) {
+              return options.customRowRender(row, dataIndex, rowIndex);
+            }
 
             return (
               <React.Fragment key={rowIndex}>

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -120,53 +120,61 @@ class TableBody extends React.Component {
     return (
       <MuiTableBody>
         {tableRows && tableRows.length > 0 ? (
-          tableRows.map(({ data: row, dataIndex }, rowIndex) => (
-            <React.Fragment key={rowIndex}>
-              <TableBodyRow
-                {...(options.setRowProps ? options.setRowProps(row, dataIndex) : {})}
-                options={options}
-                rowSelected={options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false}
-                onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
-                id={'MUIDataTableBodyRow-' + dataIndex}>
-                <TableSelectCell
-                  onChange={this.handleRowSelect.bind(null, {
-                    index: this.getRowIndex(rowIndex),
-                    dataIndex: dataIndex,
-                  })}
-                  onExpand={toggleExpandRow.bind(null, {
-                    index: this.getRowIndex(rowIndex),
-                    dataIndex: dataIndex,
-                  })}
-                  fixedHeader={options.fixedHeader}
-                  checked={this.isRowSelected(dataIndex)}
-                  expandableOn={options.expandableRows}
-                  selectableOn={options.selectableRows}
-                  isRowExpanded={this.isRowExpanded(dataIndex)}
-                  isRowSelectable={this.isRowSelectable(dataIndex)}
-                  id={'MUIDataTableSelectCell-' + dataIndex}
-                />
-                {row.map(
-                  (column, columnIndex) =>
-                    columns[columnIndex].display === 'true' && (
-                      <TableBodyCell
-                        {...(columns[columnIndex].setCellProps
-                          ? columns[columnIndex].setCellProps(column, dataIndex, columnIndex)
-                          : {})}
-                        dataIndex={dataIndex}
-                        rowIndex={rowIndex}
-                        colIndex={columnIndex}
-                        columnHeader={columns[columnIndex].label}
-                        print={columns[columnIndex].print}
-                        options={options}
-                        key={columnIndex}>
-                        {column}
-                      </TableBodyCell>
-                    ),
-                )}
-              </TableBodyRow>
-              {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex })}
-            </React.Fragment>
-          ))
+          tableRows.map((data, rowIndex) => {
+            if (options.customRowRender) {
+              return options.customRowRender(data, rowIndex);
+            }
+
+            const { data: row, dataIndex } = data;
+
+            return (
+              <React.Fragment key={rowIndex}>
+                <TableBodyRow
+                  {...(options.setRowProps ? options.setRowProps(row, dataIndex) : {})}
+                  options={options}
+                  rowSelected={options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false}
+                  onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
+                  id={'MUIDataTableBodyRow-' + dataIndex}>
+                  <TableSelectCell
+                    onChange={this.handleRowSelect.bind(null, {
+                      index: this.getRowIndex(rowIndex),
+                      dataIndex: dataIndex,
+                    })}
+                    onExpand={toggleExpandRow.bind(null, {
+                      index: this.getRowIndex(rowIndex),
+                      dataIndex: dataIndex,
+                    })}
+                    fixedHeader={options.fixedHeader}
+                    checked={this.isRowSelected(dataIndex)}
+                    expandableOn={options.expandableRows}
+                    selectableOn={options.selectableRows}
+                    isRowExpanded={this.isRowExpanded(dataIndex)}
+                    isRowSelectable={this.isRowSelectable(dataIndex)}
+                    id={'MUIDataTableSelectCell-' + dataIndex}
+                  />
+                  {row.map(
+                    (column, columnIndex) =>
+                      columns[columnIndex].display === 'true' && (
+                        <TableBodyCell
+                          {...(columns[columnIndex].setCellProps
+                            ? columns[columnIndex].setCellProps(column, dataIndex, columnIndex)
+                            : {})}
+                          dataIndex={dataIndex}
+                          rowIndex={rowIndex}
+                          colIndex={columnIndex}
+                          columnHeader={columns[columnIndex].label}
+                          print={columns[columnIndex].print}
+                          options={options}
+                          key={columnIndex}>
+                          {column}
+                        </TableBodyCell>
+                      ),
+                  )}
+                </TableBodyRow>
+                {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex })}
+              </React.Fragment>
+            );
+          })
         ) : (
           <TableBodyRow options={options}>
             <TableBodyCell

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -75,13 +75,13 @@ class TablePagination extends React.Component {
               id: 'pagination-next',
               'aria-label': textLabels.next,
             }}
-            SelectProps= {{
+            SelectProps={{
               id: 'pagination-input',
               SelectDisplayProps: { id: 'pagination-rows' },
               MenuProps: {
                 id: 'pagination-menu',
-                MenuListProps: { id: 'pagination-menu-list' }
-              }
+                MenuListProps: { id: 'pagination-menu-list' },
+              },
             }}
             rowsPerPageOptions={options.rowsPerPageOptions}
             onChangePage={this.handlePageChange}

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -30,7 +30,10 @@ describe('<MUIDataTable />', function() {
       { name: 'Name', options: { customBodyRender: renderName, customFilterListRender: renderCustomFilterList } },
       'Company',
       { name: 'City', label: 'City Label', options: { customBodyRender: renderCities, filterType: 'textField' } },
-      { name: 'State', options: { customBodyRender: renderState, filterType: 'multiselect', customHeadRender: renderHead } },
+      {
+        name: 'State',
+        options: { customBodyRender: renderState, filterType: 'multiselect', customHeadRender: renderHead },
+      },
       { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
     ];
     data = [
@@ -199,18 +202,27 @@ describe('<MUIDataTable />', function() {
       rowsPerPage: 1,
       rowsPerPageOptions: [1, 2, 4],
       page: 1,
-      onChangePage: current => currentPage = current,
+      onChangePage: current => (currentPage = current),
     };
     const fullWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
 
     // simulate paging backward to set `currentPage`
-    fullWrapper.find('#pagination-back').at(0).simulate('click');
+    fullWrapper
+      .find('#pagination-back')
+      .at(0)
+      .simulate('click');
     assert.strictEqual(currentPage, 0);
 
     // simulate changing pagination to set `rowsPerPage`
     fullWrapper.find('#pagination-rows').simulate('click');
-    fullWrapper.find('#pagination-menu-list li').at(1).simulate('click');
-    let inputValue = fullWrapper.find('#pagination-input').at(0).text();
+    fullWrapper
+      .find('#pagination-menu-list li')
+      .at(1)
+      .simulate('click');
+    let inputValue = fullWrapper
+      .find('#pagination-input')
+      .at(0)
+      .text();
     assert.strictEqual(inputValue, '2');
 
     // add data to simulate state change
@@ -219,11 +231,17 @@ describe('<MUIDataTable />', function() {
     fullWrapper.setProps({ data: newData });
 
     // simulate paging forward to test whether or not the `currentPage` was reset
-    fullWrapper.find('#pagination-next').at(0).simulate('click');
+    fullWrapper
+      .find('#pagination-next')
+      .at(0)
+      .simulate('click');
     assert.strictEqual(currentPage, 1);
 
     // grab pagination value to test whether or not `rowsPerPage` was reset
-    inputValue = fullWrapper.find('#pagination-input').at(0).text();
+    inputValue = fullWrapper
+      .find('#pagination-input')
+      .at(0)
+      .text();
     assert.strictEqual(inputValue, '2');
 
     // test that data updated properly

--- a/test/MUIDataTableBody.test.js
+++ b/test/MUIDataTableBody.test.js
@@ -263,4 +263,31 @@ describe('<TableBody />', function() {
     assert.isAtLeast(options.setRowProps.callCount, 1);
     assert(options.setRowProps.calledWith(data[1]));
   });
+
+  it("should use 'customRowRender' when provided", () => {
+    const options = { customRowRender: () => <div>Test_Text</div> };
+    const selectRowUpdate = stub();
+    const toggleExpandRow = () => {};
+
+    const t = mount(
+      <TableBody
+        data={displayData}
+        count={displayData.length}
+        columns={columns}
+        page={0}
+        rowsPerPage={10}
+        selectedRows={[]}
+        selectRowUpdate={selectRowUpdate}
+        expandedRows={[]}
+        toggleExpandRow={toggleExpandRow}
+        options={options}
+        searchText={''}
+        filterList={[]}
+      />,
+    );
+
+    const html = t.html();
+    
+    assert.notEqual(html.indexOf("Test_Text"), -1);
+  });
 });

--- a/test/MUIDataTableBody.test.js
+++ b/test/MUIDataTableBody.test.js
@@ -207,7 +207,7 @@ describe('<TableBody />', function() {
     const selectRowUpdate = stub();
     const toggleExpandRow = () => {};
 
-    const t = mount(
+    const mountWrapper = mount(
       <TableBody
         data={displayData}
         count={displayData.length}
@@ -224,7 +224,7 @@ describe('<TableBody />', function() {
       />,
     );
 
-    t.find('#MUIDataTableBodyRow-2')
+    mountWrapper.find('#MUIDataTableBodyRow-2')
       .first()
       .simulate('click');
 
@@ -237,7 +237,7 @@ describe('<TableBody />', function() {
     const selectRowUpdate = stub();
     const toggleExpandRow = () => {};
 
-    const t = mount(
+    const mountWrapper = mount(
       <TableBody
         data={displayData}
         count={displayData.length}
@@ -254,7 +254,7 @@ describe('<TableBody />', function() {
       />,
     );
 
-    const props = t
+    const props = mountWrapper
       .find('#MUIDataTableBodyRow-1')
       .first()
       .props();
@@ -269,7 +269,7 @@ describe('<TableBody />', function() {
     const selectRowUpdate = stub();
     const toggleExpandRow = () => {};
 
-    const t = mount(
+    const mountWrapper = mount(
       <TableBody
         data={displayData}
         count={displayData.length}
@@ -286,8 +286,8 @@ describe('<TableBody />', function() {
       />,
     );
 
-    const html = t.html();
-    
-    assert.notEqual(html.indexOf("Test_Text"), -1);
+    const html = mountWrapper.html();
+
+    expect(html).to.contain("Test_Text");
   });
 });

--- a/test/MUIDataTableHead.test.js
+++ b/test/MUIDataTableHead.test.js
@@ -21,12 +21,8 @@ describe('<TableHead />', function() {
         label: 'State',
         display: 'true',
         options: { fixedHeader: true },
-        customHeadRender: columnMeta => (
-          <TableHeadCell {...columnMeta}>
-            {columnMeta.name + 's'}
-          </TableHeadCell>
-        ),
-        sort: null
+        customHeadRender: columnMeta => <TableHeadCell {...columnMeta}>{columnMeta.name + 's'}</TableHeadCell>,
+        sort: null,
       },
     ];
 


### PR DESCRIPTION
I have a use-case in my project where I need a non-column based layout for smaller screens. This is to prevent horizontal scrolling, which is not a very good UX on mobile.
I still wanted to make use of the (great) filtering and sorting system of mui-datatables.

This PR adds a new `customRowRender` option to mui-datatables, that can be used like this:

```
customRowRender: ({ data }, rowIndex) => (
  <div>
    My Important data field: {data[0]}
  </div>
)
```