### PR TITLE
Bugfix/issues 561 and 600 toolbar problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "2.0.0-beta.59",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -57,7 +57,7 @@ class Popover extends React.Component {
       horizontal: 'center',
     };
 
-    const triggerEl = React.cloneElement(trigger, {
+    const triggerEl = React.cloneElement(<span>{trigger}</span>, {
       key: 'content',
       ref: el => (this.anchorEl = el),
       onClick: () => {

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -23,10 +23,7 @@ class TableFilterList extends React.Component {
     filterListRenderers: PropTypes.array.isRequired,
     /** Columns used to describe table */
     columnNames: PropTypes.PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.shape({ name: PropTypes.string.isRequired }),
-      ]),
+      PropTypes.oneOfType([PropTypes.string, PropTypes.shape({ name: PropTypes.string.isRequired })]),
     ).isRequired,
     /** Callback to trigger filter update */
     onFilterUpdate: PropTypes.func,

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -181,7 +181,7 @@ class TableToolbar extends React.Component {
         </div>
         <div className={classes.actions}>
           {options.search && (
-            <Tooltip title={search}>
+            <Tooltip title={search} disableFocusListener>
               <IconButton
                 aria-label={search}
                 buttonRef={el => (this.searchButton = el)}
@@ -216,7 +216,7 @@ class TableToolbar extends React.Component {
             <Popover
               refExit={this.setActiveIcon.bind(null)}
               trigger={
-                <Tooltip title={viewColumns}>
+                <Tooltip title={viewColumns} disableFocusListener>
                   <IconButton
                     aria-label={viewColumns}
                     classes={{ root: this.getActiveIcon(classes, 'viewcolumns') }}
@@ -235,7 +235,7 @@ class TableToolbar extends React.Component {
               refExit={this.setActiveIcon.bind(null)}
               classes={{ paper: classes.filterPaper }}
               trigger={
-                <Tooltip title={filterTable}>
+                <Tooltip title={filterTable} disableFocusListener>
                   <IconButton
                     aria-label={filterTable}
                     classes={{ root: this.getActiveIcon(classes, 'filter') }}

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -416,7 +416,12 @@ describe('<MUIDataTable />', function() {
     const columnNames = columns.map(column => ({ name: column.name }));
 
     const mountWrapper = mount(
-      <TableFilterList filterList={filterList} filterListRenderers={filterListRenderers} filterUpdate={() => true} columnNames={columnNames} />,
+      <TableFilterList
+        filterList={filterList}
+        filterListRenderers={filterListRenderers}
+        filterUpdate={() => true}
+        columnNames={columnNames}
+      />,
     );
     const actualResult = mountWrapper.find(Chip);
     assert.strictEqual(actualResult.length, 1);
@@ -432,7 +437,12 @@ describe('<MUIDataTable />', function() {
     const columnNames = columns.map(column => ({ name: column.name }));
 
     const mountWrapper = mount(
-      <TableFilterList filterList={filterList} filterListRenderers={filterListRenderers} filterUpdate={() => true} columnNames={columnNames} />,
+      <TableFilterList
+        filterList={filterList}
+        filterListRenderers={filterListRenderers}
+        filterUpdate={() => true}
+        columnNames={columnNames}
+      />,
     );
     const actualResult = mountWrapper.find(Chip);
     assert.strictEqual(actualResult.length, 1);
@@ -477,7 +487,7 @@ describe('<MUIDataTable />', function() {
   it('should have the proper column name in onFilterChange when applying filters', () => {
     let changedColumn;
     const options = {
-      onFilterChange: column => changedColumn = column
+      onFilterChange: column => (changedColumn = column),
     };
 
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);


### PR DESCRIPTION
Closes https://github.com/gregnb/mui-datatables/issues/600 and https://github.com/gregnb/mui-datatables/issues/561.

- Issue 600: On later versions of material-ui, `React.cloneElement` fails to properly apply necessary props, which results in the certain toolbar options that do not have their necessary `onClick` props.
- Issue 561: Various tooltips persisted after closing their respective popovers, but is now fixed by using the `disableFocusListener` prop.