### PR TITLE
add setTableAction callback to pass to setState in initializeTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "2.0.0-beta.59",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4545,7 +4545,8 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4557,7 +4558,8 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4688,7 +4690,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4702,6 +4705,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4841,7 +4845,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4992,6 +4997,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7775,6 +7781,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9108,7 +9115,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,41 +1,42 @@
-import babel from "rollup-plugin-babel";
-import commonjs from "rollup-plugin-commonjs";
-import replace from "rollup-plugin-replace";
-import uglify from "rollup-plugin-uglify";
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
+import uglify from 'rollup-plugin-uglify';
 
 export default {
   input: 'src/index.js',
   plugins: [
     replace({
-      'process.env.NODE_ENV': JSON.stringify('production')
+      'process.env.NODE_ENV': JSON.stringify('production'),
     }),
     commonjs({
-      include: [
-        'node_modules/**'
-      ]
+      include: ['node_modules/**'],
     }),
     babel({
-      "presets": [
-        "react",
-        ["env", {
-          "targets": {
-            "browsers": ["last 2 versions", "ie >= 10"]
+      presets: [
+        'react',
+        [
+          'env',
+          {
+            targets: {
+              browsers: ['last 2 versions', 'ie >= 10'],
+            },
+            debug: false,
+            modules: false,
           },
-          "debug": false,
-          "modules": false
-        }]
+        ],
       ],
-      "plugins": [
-        "external-helpers",
-        "transform-object-rest-spread",
-        "babel-plugin-transform-class-properties",
-        "transform-react-remove-prop-types"
+      plugins: [
+        'external-helpers',
+        'transform-object-rest-spread',
+        'babel-plugin-transform-class-properties',
+        'transform-react-remove-prop-types',
       ],
-      babelrc: false
+      babelrc: false,
     }),
     uglify({
       compress: {
-        warnings: false,
+        //        warnings: false,
         conditionals: true,
         unused: true,
         comparisons: true,
@@ -47,13 +48,13 @@ export default {
       },
       output: {
         comments: false,
-      }
-    })
+      },
+    }),
   ],
   output: {
     file: 'dist/index.js',
     format: 'cjs',
-    exports: 'named'
+    exports: 'named',
   },
-  sourcemap: true
+  sourcemap: true,
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ export default {
     }),
     uglify({
       compress: {
-        //        warnings: false,
+        // warnings: false,
         conditionals: true,
         unused: true,
         comparisons: true,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -192,7 +192,7 @@ class MUIDataTable extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
-        this.setTableInit('tablePropsUpdated');
+        this.setTableAction('tablePropsUpdated');
       });
     }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -202,7 +202,9 @@ class MUIDataTable extends React.Component {
   initializeTable(props) {
     this.getDefaultOptions(props);
     this.setTableOptions(props);
-    this.setTableData(props, TABLE_LOAD.INITIAL);
+    this.setTableData(props, TABLE_LOAD.INITIAL, () => {
+      this.setTableAction('tableLoadInitial');
+    });
   }
 
   /*

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -190,7 +190,9 @@ class MUIDataTable extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
-      this.setTableData(prevProps, TABLE_LOAD.INITIAL);
+      this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
+        this.setTableAction('tableLoadInitial');
+      });
     }
 
     if (this.options.resizableColumns) {
@@ -374,9 +376,7 @@ class MUIDataTable extends React.Component {
     let { columns, filterData, filterList } = this.buildColumns(props.columns);
     let sortIndex = null;
     let sortDirection = null;
-
     const data = status === TABLE_LOAD.INITIAL ? this.transformData(columns, props.data) : props.data;
-
     columns.forEach((column, colIndex) => {
       for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
         let value = status === TABLE_LOAD.INITIAL ? data[rowIndex][colIndex] : data[rowIndex].data[colIndex];

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -117,6 +117,7 @@ class MUIDataTable extends React.Component {
       isRowSelectable: PropTypes.func,
       serverSide: PropTypes.bool,
       onTableChange: PropTypes.func,
+      onTableInit: PropTypes.func,
       caseSensitive: PropTypes.bool,
       rowHover: PropTypes.bool,
       fixedHeader: PropTypes.bool,
@@ -191,7 +192,7 @@ class MUIDataTable extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
-        this.setTableAction('tableLoadInitial');
+        this.setTableInit('tablePropsUpdated');
       });
     }
 
@@ -205,7 +206,7 @@ class MUIDataTable extends React.Component {
     this.getDefaultOptions(props);
     this.setTableOptions(props);
     this.setTableData(props, TABLE_LOAD.INITIAL, () => {
-      this.setTableAction('tableLoadInitial');
+      this.setTableInit('tableLoadInitial');
     });
   }
 
@@ -265,6 +266,12 @@ class MUIDataTable extends React.Component {
   setTableAction = action => {
     if (typeof this.options.onTableChange === 'function') {
       this.options.onTableChange(action, this.state);
+    }
+  };
+
+  setTableInit = action => {
+    if (typeof this.options.onTableInit === 'function') {
+      this.options.onTableInit(action, this.state);
     }
   };
 

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -75,13 +75,13 @@ class TablePagination extends React.Component {
               id: 'pagination-next',
               'aria-label': textLabels.next,
             }}
-            SelectProps= {{
+            SelectProps={{
               id: 'pagination-input',
               SelectDisplayProps: { id: 'pagination-rows' },
               MenuProps: {
                 id: 'pagination-menu',
-                MenuListProps: { id: 'pagination-menu-list' }
-              }
+                MenuListProps: { id: 'pagination-menu-list' },
+              },
             }}
             rowsPerPageOptions={options.rowsPerPageOptions}
             onChangePage={this.handlePageChange}

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -30,7 +30,10 @@ describe('<MUIDataTable />', function() {
       { name: 'Name', options: { customBodyRender: renderName, customFilterListRender: renderCustomFilterList } },
       'Company',
       { name: 'City', label: 'City Label', options: { customBodyRender: renderCities, filterType: 'textField' } },
-      { name: 'State', options: { customBodyRender: renderState, filterType: 'multiselect', customHeadRender: renderHead } },
+      {
+        name: 'State',
+        options: { customBodyRender: renderState, filterType: 'multiselect', customHeadRender: renderHead },
+      },
       { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
     ];
     data = [
@@ -199,18 +202,27 @@ describe('<MUIDataTable />', function() {
       rowsPerPage: 1,
       rowsPerPageOptions: [1, 2, 4],
       page: 1,
-      onChangePage: current => currentPage = current,
+      onChangePage: current => (currentPage = current),
     };
     const fullWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
 
     // simulate paging backward to set `currentPage`
-    fullWrapper.find('#pagination-back').at(0).simulate('click');
+    fullWrapper
+      .find('#pagination-back')
+      .at(0)
+      .simulate('click');
     assert.strictEqual(currentPage, 0);
 
     // simulate changing pagination to set `rowsPerPage`
     fullWrapper.find('#pagination-rows').simulate('click');
-    fullWrapper.find('#pagination-menu-list li').at(1).simulate('click');
-    let inputValue = fullWrapper.find('#pagination-input').at(0).text();
+    fullWrapper
+      .find('#pagination-menu-list li')
+      .at(1)
+      .simulate('click');
+    let inputValue = fullWrapper
+      .find('#pagination-input')
+      .at(0)
+      .text();
     assert.strictEqual(inputValue, '2');
 
     // add data to simulate state change
@@ -219,11 +231,17 @@ describe('<MUIDataTable />', function() {
     fullWrapper.setProps({ data: newData });
 
     // simulate paging forward to test whether or not the `currentPage` was reset
-    fullWrapper.find('#pagination-next').at(0).simulate('click');
+    fullWrapper
+      .find('#pagination-next')
+      .at(0)
+      .simulate('click');
     assert.strictEqual(currentPage, 1);
 
     // grab pagination value to test whether or not `rowsPerPage` was reset
-    inputValue = fullWrapper.find('#pagination-input').at(0).text();
+    inputValue = fullWrapper
+      .find('#pagination-input')
+      .at(0)
+      .text();
     assert.strictEqual(inputValue, '2');
 
     // test that data updated properly

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -727,6 +727,15 @@ describe('<MUIDataTable />', function() {
     assert.strictEqual(options.onTableChange.callCount, 1);
   });
 
+  it('should call onTableInit on create', () => {
+    const options = { selectableRows: true, onTableInit: spy() };
+
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />).dive();
+    const instance = shallowWrapper.instance();
+
+    assert.strictEqual(options.onTableInit.callCount, 1);
+  });
+
   it('should call onTableChange when calling selectRowUpdate method with type=cell', () => {
     const options = { selectableRows: true, onTableChange: spy() };
 

--- a/test/MUIDataTableHead.test.js
+++ b/test/MUIDataTableHead.test.js
@@ -21,12 +21,8 @@ describe('<TableHead />', function() {
         label: 'State',
         display: 'true',
         options: { fixedHeader: true },
-        customHeadRender: columnMeta => (
-          <TableHeadCell {...columnMeta}>
-            {columnMeta.name + 's'}
-          </TableHeadCell>
-        ),
-        sort: null
+        customHeadRender: columnMeta => <TableHeadCell {...columnMeta}>{columnMeta.name + 's'}</TableHeadCell>,
+        sort: null,
       },
     ];
 


### PR DESCRIPTION
API users who need to track the internal MUIDataTable state don't get the callback unless and until some event modifies the table. 

My change provides a callback to call setTableAction('tableLoadInitial')
in initializeTable() for clients who use onTableChange to track table state. 
