### PR TITLE
Improve grid spacing in filters dialog

### DIFF
--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -18,7 +18,7 @@ import { TextField, Grid, GridList, GridListTile } from '@material-ui/core';
 export const defaultFilterStyles = theme => ({
   root: {
     backgroundColor: theme.palette.background.default,
-    padding: '24px',
+    padding: '24px 24px 36px 24px',
     fontFamily: 'Roboto',
   },
   header: {
@@ -291,7 +291,7 @@ class TableFilter extends React.Component {
           </div>
           <div className={classes.filtersSelected} />
         </div>
-        <GridList cellHeight="auto" cols={filterGridColumns} cellHeight={70} spacing={34}>
+        <GridList cellHeight="auto" cols={filterGridColumns} cellHeight={64} spacing={34}>
           {columns.map((column, index) => {
             if (column.filter) {
               const filterType = column.filterType || options.filterType;

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -18,7 +18,7 @@ import { TextField, Grid, GridList, GridListTile } from '@material-ui/core';
 export const defaultFilterStyles = theme => ({
   root: {
     backgroundColor: theme.palette.background.default,
-    padding: '16px 24px 16px 24px',
+    padding: '24px',
     fontFamily: 'Roboto',
   },
   header: {
@@ -90,9 +90,7 @@ export const defaultFilterStyles = theme => ({
     justifyContent: 'space-between',
   },
   selectFormControl: {
-    flex: '1 1 calc(50% - 24px)',
-    marginRight: '24px',
-    marginBottom: '24px',
+    flex: '1 1 calc(50% - 24px)'
   },
   /* textField */
   textFieldRoot: {
@@ -104,8 +102,6 @@ export const defaultFilterStyles = theme => ({
   },
   textFieldFormControl: {
     flex: '1 1 calc(50% - 24px)',
-    marginRight: '24px',
-    marginBottom: '24px',
   },
 });
 
@@ -295,7 +291,7 @@ class TableFilter extends React.Component {
           </div>
           <div className={classes.filtersSelected} />
         </div>
-        <GridList cellHeight="auto" cols={filterGridColumns}>
+        <GridList cellHeight="auto" cols={filterGridColumns} cellHeight={70} spacing={34}>
           {columns.map((column, index) => {
             if (column.filter) {
               const filterType = column.filterType || options.filterType;


### PR DESCRIPTION
In particular, the way margins were set, we had asymetry on the second column as well as a waste of space