### PR TITLE
Bugfix/remove deprecated rollup config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7772,7 +7772,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
@@ -7783,25 +7783,25 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
           "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
@@ -7810,61 +7810,61 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
           "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
           "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
@@ -7875,7 +7875,7 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
@@ -7891,7 +7891,7 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
@@ -7900,7 +7900,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
@@ -7910,7 +7910,7 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
@@ -7923,7 +7923,7 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
@@ -7940,7 +7940,7 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
@@ -7952,19 +7952,19 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
@@ -7979,7 +7979,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -7988,7 +7988,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
@@ -7997,7 +7997,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
@@ -8006,7 +8006,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
@@ -8017,13 +8017,13 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -8031,7 +8031,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -8041,7 +8041,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
@@ -8059,7 +8059,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -8070,13 +8070,13 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
@@ -8093,7 +8093,7 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -8101,7 +8101,7 @@
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
@@ -8112,14 +8112,14 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
@@ -8130,7 +8130,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8143,7 +8143,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
@@ -8155,7 +8155,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -8164,7 +8164,7 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -8172,7 +8172,7 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
@@ -8184,7 +8184,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
@@ -8193,13 +8193,13 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
@@ -8209,43 +8209,43 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
           "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
           "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
           "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
           "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
           "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
@@ -8255,7 +8255,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
@@ -8264,25 +8264,25 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
           "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
@@ -8291,7 +8291,7 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
@@ -8301,7 +8301,7 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
@@ -8310,7 +8310,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
@@ -8319,7 +8319,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
@@ -8330,13 +8330,13 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -8344,7 +8344,7 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
@@ -8353,7 +8353,7 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
@@ -8362,19 +8362,19 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -8389,7 +8389,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
@@ -8402,7 +8402,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
@@ -8417,7 +8417,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -8426,7 +8426,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -8437,7 +8437,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
@@ -8447,7 +8447,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
@@ -8458,7 +8458,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
@@ -8474,7 +8474,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -8483,7 +8483,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -8492,7 +8492,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
@@ -8501,7 +8501,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
@@ -8510,7 +8510,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
@@ -8521,7 +8521,7 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -8529,7 +8529,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -8541,7 +8541,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -8552,7 +8552,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
@@ -8563,7 +8563,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -8572,13 +8572,13 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
@@ -8588,7 +8588,7 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
@@ -8597,31 +8597,31 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
           "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
           "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
@@ -8635,19 +8635,19 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
@@ -8659,7 +8659,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
@@ -8670,7 +8670,7 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
@@ -8679,13 +8679,13 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
@@ -8696,7 +8696,7 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -8704,7 +8704,7 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
@@ -8714,7 +8714,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
@@ -8723,7 +8723,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -8734,7 +8734,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
@@ -8745,19 +8745,19 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
           "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -8767,13 +8767,13 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
@@ -8782,13 +8782,13 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
           "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
@@ -8797,19 +8797,19 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
@@ -8818,7 +8818,7 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
@@ -8827,7 +8827,7 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
@@ -8838,7 +8838,7 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
@@ -8846,13 +8846,13 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
@@ -8861,13 +8861,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -8876,7 +8876,7 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "dev": true,
           "requires": {
@@ -8885,7 +8885,7 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
               "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
               "dev": true
             }
@@ -8893,7 +8893,7 @@
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
@@ -8902,7 +8902,7 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -8910,49 +8910,49 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
           "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
           "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
           "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
@@ -8961,7 +8961,7 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
           "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
@@ -8976,7 +8976,7 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
           "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "dev": true,
           "requires": {
@@ -8988,7 +8988,7 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
@@ -8999,7 +8999,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
           "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "dev": true,
           "requires": {
@@ -9012,7 +9012,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "dev": true,
               "requires": {
@@ -9023,7 +9023,7 @@
         },
         "istanbul-reports": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.0.tgz",
           "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "dev": true,
           "requires": {
@@ -9032,19 +9032,19 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -9053,14 +9053,14 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
           "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
@@ -9069,7 +9069,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -9082,7 +9082,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -9092,7 +9092,7 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
@@ -9100,19 +9100,19 @@
         },
         "lodash": {
           "version": "4.17.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
           "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
@@ -9121,7 +9121,7 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
@@ -9131,13 +9131,13 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
           "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
@@ -9146,7 +9146,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
@@ -9155,13 +9155,13 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
           "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
@@ -9170,7 +9170,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
@@ -9179,7 +9179,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
@@ -9187,7 +9187,7 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
@@ -9208,7 +9208,7 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -9216,13 +9216,13 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -9231,13 +9231,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "dev": true,
           "requires": {
@@ -9247,7 +9247,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
@@ -9258,7 +9258,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -9267,13 +9267,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "dev": true,
           "requires": {
@@ -9293,19 +9293,19 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
               "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
               "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -9313,7 +9313,7 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
@@ -9325,7 +9325,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -9334,19 +9334,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
@@ -9357,7 +9357,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -9368,7 +9368,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
@@ -9377,7 +9377,7 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -9385,7 +9385,7 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
@@ -9394,7 +9394,7 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -9402,7 +9402,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -9411,7 +9411,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
@@ -9421,13 +9421,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
@@ -9438,13 +9438,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
@@ -9453,7 +9453,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -9462,13 +9462,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
@@ -9477,13 +9477,13 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
           "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -9492,25 +9492,25 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
           "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
@@ -9521,19 +9521,19 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
@@ -9542,7 +9542,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
@@ -9551,7 +9551,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
@@ -9563,19 +9563,19 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
           "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
@@ -9586,7 +9586,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -9596,7 +9596,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
@@ -9608,13 +9608,13 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
@@ -9624,19 +9624,19 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
           "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
@@ -9645,37 +9645,37 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
@@ -9685,7 +9685,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
@@ -9694,7 +9694,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
@@ -9703,19 +9703,19 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
@@ -9727,7 +9727,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -9738,7 +9738,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -9747,25 +9747,25 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
@@ -9781,7 +9781,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -9790,7 +9790,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -9801,7 +9801,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
@@ -9812,7 +9812,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
@@ -9821,7 +9821,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
@@ -9830,7 +9830,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
@@ -9839,7 +9839,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
@@ -9850,13 +9850,13 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -9864,7 +9864,7 @@
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
@@ -9873,13 +9873,13 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
           "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "dev": true,
           "requires": {
@@ -9892,13 +9892,13 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
           "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
           "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
@@ -9912,7 +9912,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
@@ -9922,13 +9922,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
           "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
@@ -9938,13 +9938,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
           "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
@@ -9953,7 +9953,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
@@ -9963,7 +9963,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
@@ -9974,7 +9974,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
@@ -9984,13 +9984,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -10001,7 +10001,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10010,7 +10010,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -10019,19 +10019,19 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
           "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
@@ -10044,19 +10044,19 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
               "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
               "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "braces": {
               "version": "2.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
@@ -10074,7 +10074,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
@@ -10085,7 +10085,7 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
@@ -10100,7 +10100,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
@@ -10109,7 +10109,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
@@ -10118,7 +10118,7 @@
                 },
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
@@ -10127,7 +10127,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
@@ -10138,7 +10138,7 @@
                 },
                 "is-data-descriptor": {
                   "version": "0.1.4",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
@@ -10147,7 +10147,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
@@ -10158,7 +10158,7 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
@@ -10169,7 +10169,7 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                   "dev": true
                 }
@@ -10177,7 +10177,7 @@
             },
             "extglob": {
               "version": "2.0.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
@@ -10193,7 +10193,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
@@ -10202,7 +10202,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
@@ -10213,7 +10213,7 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
@@ -10225,7 +10225,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
@@ -10236,7 +10236,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
@@ -10245,7 +10245,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
@@ -10254,7 +10254,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
@@ -10265,7 +10265,7 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
@@ -10274,7 +10274,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
@@ -10285,19 +10285,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
@@ -10320,13 +10320,13 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
@@ -10335,7 +10335,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
@@ -10347,7 +10347,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
@@ -10357,7 +10357,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
@@ -10368,13 +10368,13 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
           "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
@@ -10386,7 +10386,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
@@ -10401,14 +10401,14 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
           "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
@@ -10420,7 +10420,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -10429,7 +10429,7 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
@@ -10443,7 +10443,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
@@ -10453,7 +10453,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
@@ -10464,7 +10464,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "dev": true,
                   "requires": {
@@ -10475,13 +10475,13 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
               "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
               "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
@@ -10489,13 +10489,13 @@
         },
         "urix": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
@@ -10504,7 +10504,7 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
@@ -10512,7 +10512,7 @@
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
@@ -10522,7 +10522,7 @@
         },
         "which": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
@@ -10531,26 +10531,26 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -10560,7 +10560,7 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
@@ -10569,7 +10569,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -10582,13 +10582,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
@@ -10599,19 +10599,19 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
           "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -10631,19 +10631,19 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
@@ -10654,7 +10654,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -10663,7 +10663,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
@@ -10674,7 +10674,7 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
@@ -10683,7 +10683,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
@@ -12466,36 +12466,12 @@
       }
     },
     "rollup-plugin-uglify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
-      "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz",
+      "integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
       "dev": true,
       "requires": {
-        "uglify-js": "^3.0.9"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "dev": true,
-          "requires": {
-            "commander": "~2.17.1",
-            "source-map": "~0.6.1"
-          }
-        }
+        "uglify-es": "^3.3.7"
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
-    "rollup-plugin-uglify": "^2.0.1",
+    "rollup-plugin-uglify": "^3.0.0",
     "simulant": "^0.2.2",
     "sinon": "^4.1.3",
     "webpack": "^3.9.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,6 @@ export default {
     }),
     uglify({
       compress: {
-        warnings: false,
         conditionals: true,
         unused: true,
         comparisons: true,

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -33,7 +33,7 @@ const defaultHeadCellStyles = theme => ({
     cursor: 'pointer',
     paddingLeft: '4px',
     height: '10px',
-    position: 'absolute'
+    position: 'absolute',
   },
   sortActive: {
     color: theme.palette.text.primary,

--- a/src/components/TableHeadRow.js
+++ b/src/components/TableHeadRow.js
@@ -5,7 +5,7 @@ import TableRow from '@material-ui/core/TableRow';
 import { withStyles } from '@material-ui/core/styles';
 
 const defaultHeadRowStyles = {
-  root: {}
+  root: {},
 };
 
 class TableHeadRow extends React.Component {


### PR DESCRIPTION
People using `yarn upgrade` are running into issues with the deprecated `warnings` option: https://stackoverflow.com/questions/55989693/warnings-is-not-a-supported-option-error-from-uglifyjs.