### PR TITLE
Allow search bar to be shown when switching between toolbars

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -84,7 +84,7 @@ export const responsiveToolbarStyles = theme => ({
 class TableToolbar extends React.Component {
   state = {
     iconActive: null,
-    showSearch: Boolean(this.props.options.searchText),
+    showSearch: Boolean(this.props.searchText || this.props.options.searchText),
     searchText: this.props.searchText || null,
   };
 


### PR DESCRIPTION
Only handles the case where the search bar has entered text.

Helps https://github.com/gregnb/mui-datatables/issues/653.