### PR TITLE
Add brushing support for multiple-view applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The component accepts the following props:
 |**`count`**|number||User provided override for total number of rows
 |**`serverSide`**|boolean|false|Enable remote data source
 |**`rowsSelected`**|array||User provided selected rows
+|**`rowsHighlighted`**|array||User provided highlighted rows
 |**`filterType `**|string||Choice of filtering view. `enum('checkbox', 'dropdown', 'multiselect', 'textField')`
 |**`textLabels `**|object||User provided labels to localize text
 |**`pagination`**|boolean|true|Enable/disable pagination
@@ -172,6 +173,8 @@ The component accepts the following props:
 |**`onRowsSelect`**|function||Callback function that triggers when row(s) are selected. `function(currentRowsSelected: array, allRowsSelected: array) => void`
 |**`onRowsDelete`**|function||Callback function that triggers when row(s) are deleted. `function(rowsDeleted: object(lookup: {dataindex: boolean}, data: arrayOfObjects: {index, dataIndex})) => void OR false` (Returning `false` prevents row deletion.)
 |**`onRowClick`**|function||Callback function that triggers when a row is clicked. `function(rowData: string[], rowMeta: { dataIndex: number, rowIndex: number }) => void`
+|**`onRowMouseEnter`**|function||Callback function that triggers when the mouse enters a row. `function(rowData: string[], rowMeta: { dataIndex: number, rowIndex: number }) => void`
+|**`onRowMouseLeave`**|function||Callback function that triggers when the mouse leaves a row. `function(rowData: string[], rowMeta: { dataIndex: number, rowIndex: number }) => void`
 |**`onCellClick`**|function||Callback function that triggers when a cell is clicked. `function(colData: any, cellMeta: { colIndex: number, rowIndex: number, dataIndex: number }) => void`
 |**`onChangePage`**|function||Callback function that triggers when a page has changed. `function(currentPage: number) => void`
 |**`onChangeRowsPerPage`**|function||Callback function that triggers when the number of rows per page has changed. `function(numberOfRows: number) => void`

--- a/examples/brushing/index.js
+++ b/examples/brushing/index.js
@@ -1,0 +1,58 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
+
+import MUIDataTable from "../../src/";
+
+const getMuiTheme = () => createMuiTheme({
+  overrides: {
+    MUIDataTableBodyRow: {
+      hover: {
+        '&:hover': {
+          backgroundColor: '#dcdcdc !important'
+        }
+      },
+      highlight: {
+        backgroundColor: '#dcdcdc'
+      }
+    }
+  }
+});
+
+class Example extends React.Component {
+
+  render() {
+
+    const columns = ["Name", "Title", "Location"];
+
+    const data = [
+      ["Gabby George", "Business Analyst", "Minneapolis"],
+      ["Aiden Lloyd", "Business Consultant", "Dallas"],
+      ["Jaden Collins", "Attorney", "Santa Ana"],
+      ["Franky Rees", "Business Analyst", "St. Petersburg"],
+      ["Aaren Rose", null, "Toledo"]
+    ];
+
+    const options = {
+      filter: true,
+      filterType: 'dropdown',
+      responsive: 'stacked',
+      rowsHighlighted: [0, 3],
+      onRowMouseEnter: (rowData, rowState) => {
+        console.log(`Highlight ${rowData[0]}`);
+      },
+      onRowMouseLeave: (rowData, rowState) => {
+        console.log(`Remove highlight ${rowData[0]}`);
+      },
+    };
+
+    return (
+      <MuiThemeProvider theme={getMuiTheme()}>
+        <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+      </MuiThemeProvider>
+    );
+
+  }
+}
+
+ReactDOM.render(<Example />, document.getElementById("app-root"));

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -133,6 +133,7 @@ class MUIDataTable extends React.Component {
       page: PropTypes.number,
       count: PropTypes.number,
       rowsSelected: PropTypes.array,
+      rowsHighlighted: PropTypes.array,
       rowsPerPage: PropTypes.number,
       rowsPerPageOptions: PropTypes.array,
       filter: PropTypes.bool,
@@ -174,6 +175,10 @@ class MUIDataTable extends React.Component {
     filterList: [],
     selectedRows: {
       data: [],
+      lookup: {},
+    },
+    highlightedRows: {
+      date: [],
       lookup: {},
     },
     expandedRows: {
@@ -473,22 +478,14 @@ class MUIDataTable extends React.Component {
       lookup: {},
     };
 
+    let highlightedRowsData = {
+      data: [],
+      lookup: {},
+    };
+
     if (TABLE_LOAD.INITIAL) {
-      if (options.rowsSelected && options.rowsSelected.length) {
-        options.rowsSelected.forEach(row => {
-          let rowPos = row;
-
-          for (let cIndex = 0; cIndex < this.state.displayData.length; cIndex++) {
-            if (this.state.displayData[cIndex].dataIndex === row) {
-              rowPos = cIndex;
-              break;
-            }
-          }
-
-          selectedRowsData.data.push({ index: rowPos, dataIndex: row });
-          selectedRowsData.lookup[row] = true;
-        });
-      }
+      selectedRowsData = this.indexRows(options.rowsSelected);
+      highlightedRowsData = this.indexRows(options.rowsHighlighted);
     }
 
     if (!options.serverSide && sortIndex !== null) {
@@ -504,11 +501,40 @@ class MUIDataTable extends React.Component {
         searchText: searchText,
         selectedRows: selectedRowsData,
         count: options.count,
+        highlightedRows: highlightedRowsData,
         data: tableData,
         displayData: this.getDisplayData(columns, tableData, filterList, searchText),
       }),
       callback,
     );
+  }
+
+  /*
+   *  Index a set of rows (eg: selectedRows/highlightedRows)
+   */
+  indexRows(rows) {
+    let indexData = {
+      data: [],
+      lookup: {},
+    };
+
+    if ( rows && rows.length ) {
+      rows.forEach(row => {
+        let rowPos = row;
+
+        for (let cIndex = 0; cIndex < this.state.displayData.length; cIndex++) {
+          if (this.state.displayData[cIndex].dataIndex === row) {
+            rowPos = cIndex;
+            break;
+          }
+        }
+
+        indexData.data.push({ index: rowPos, dataIndex: row });
+        indexData.lookup[row] = true;
+      });
+    }
+
+    return indexData;
   }
 
   /*
@@ -1081,6 +1107,7 @@ class MUIDataTable extends React.Component {
       filterData,
       filterList,
       selectedRows,
+      highlightedRows,
       expandedRows,
       searchText,
     } = this.state;
@@ -1167,6 +1194,7 @@ class MUIDataTable extends React.Component {
               rowsPerPage={rowsPerPage}
               selectedRows={selectedRows}
               selectRowUpdate={this.selectRowUpdate}
+              highlightedRows={highlightedRows}
               expandedRows={expandedRows}
               toggleExpandRow={this.toggleExpandRow}
               options={this.options}

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -28,10 +28,16 @@ class TableBody extends React.Component {
     filterList: PropTypes.array,
     /** Callback to execute when row is clicked */
     onRowClick: PropTypes.func,
+    /** Callback to execute when the mouse enters a row */
+    onRowMouseEnter: PropTypes.func,
+    /** Callback to execute when the mouse leaves a row */
+    onRowMouseLeave: PropTypes.func,
     /** Table rows selected */
     selectedRows: PropTypes.object,
     /** Callback to trigger table row select */
     selectRowUpdate: PropTypes.func,
+    /** Table rows highlighted */
+    highlightedRows: PropTypes.object,
     /** Data used to search table against */
     searchText: PropTypes.string,
     /** Toggle row expandable */
@@ -85,6 +91,11 @@ class TableBody extends React.Component {
   isRowSelected(dataIndex) {
     const { selectedRows } = this.props;
     return selectedRows.lookup && selectedRows.lookup[dataIndex] ? true : false;
+  }
+
+  isRowHighlighted(dataIndex) {
+    const { highlightedRows } = this.props;
+    return highlightedRows.lookup && highlightedRows.lookup[dataIndex] ? true : false;
   }
 
   isRowExpanded(dataIndex) {
@@ -141,6 +152,14 @@ class TableBody extends React.Component {
     this.props.options.onRowClick && this.props.options.onRowClick(row, data, event);
   };
 
+  handleRowMouseEnter = (row, data, event) => {
+    this.props.options.onRowMouseEnter && this.props.options.onRowMouseEnter(row, data, event);
+  };
+
+  handleRowMouseLeave = (row, data, event) => {
+    this.props.options.onRowMouseLeave && this.props.options.onRowMouseLeave(row, data, event);
+  };
+
   render() {
     const { classes, columns, toggleExpandRow, options } = this.props;
     const tableRows = this.buildRows();
@@ -162,7 +181,10 @@ class TableBody extends React.Component {
                   {...(options.setRowProps ? options.setRowProps(row, dataIndex) : {})}
                   options={options}
                   rowSelected={options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false}
+                  rowHighlighted={this.isRowHighlighted(dataIndex)}
                   onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
+                  onMouseEnter={this.handleRowMouseEnter.bind(null, row, { rowIndex, dataIndex })}
+                  onMouseLeave={this.handleRowMouseLeave.bind(null, row, { rowIndex, dataIndex })}
                   id={'MUIDataTableBodyRow-' + dataIndex}>
                   <TableSelectCell
                     onChange={this.handleRowSelect.bind(null, {

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 const defaultBodyRowStyles = theme => ({
   root: {},
   hover: {},
+  highlight: {},
   hoverCursor: { cursor: 'pointer' },
   responsiveStacked: {
     [theme.breakpoints.down('sm')]: {
@@ -21,25 +22,34 @@ class TableBodyRow extends React.Component {
     options: PropTypes.object.isRequired,
     /** Callback to execute when row is clicked */
     onClick: PropTypes.func,
+    /** Callback to execute when the mouse enters a row */
+    onMouseEnter: PropTypes.func,
+    /** Callback to execute when the mouse leaves a row */
+    onMouseLeave: PropTypes.func,
     /** Current row selected or not */
     rowSelected: PropTypes.bool,
+    /** Current row is highlighted or not */
+    rowHighlighted: PropTypes.bool,
     /** Extend the style applied to components */
     classes: PropTypes.object,
   };
 
   render() {
-    const { classes, options, rowSelected, onClick, className, ...rest } = this.props;
+    const { classes, options, rowSelected, rowHighlighted, onClick, onMouseEnter, onMouseLeave, className, ...rest } = this.props;
 
     return (
       <TableRow
         hover={options.rowHover ? true : false}
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         className={classNames(
           {
             [classes.root]: true,
             [classes.hover]: options.rowHover,
             [classes.hoverCursor]: options.selectableRowsOnClick || options.expandableRowsOnClick,
             [classes.responsiveStacked]: options.responsive === 'stacked',
+            [classes.highlight]: rowHighlighted,
           },
           className,
         )}

--- a/test/MUIDataTableBody.test.js
+++ b/test/MUIDataTableBody.test.js
@@ -54,6 +54,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -79,6 +80,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -105,6 +107,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -131,6 +134,7 @@ describe('<TableBody />', function() {
         rowsPerPage={2}
         selectedRows={[1, 2, 3]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -159,6 +163,7 @@ describe('<TableBody />', function() {
         rowsPerPage={15}
         selectedRows={[1, 2, 3]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -187,6 +192,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -200,6 +206,35 @@ describe('<TableBody />', function() {
     shallowWrapper.update();
 
     assert.strictEqual(selectRowUpdate.callCount, 1);
+  });
+
+  it('should return correctly if row exists in highlightedRows when calling instance method isRowHighlighted', () => {
+    const options = { sort: true, selectableRows: true };
+    const selectRowUpdate = () => {};
+    const toggleExpandRow = () => {};
+
+    const shallowWrapper = shallow(
+      <TableBody
+        data={displayData}
+        count={displayData.length}
+        columns={columns}
+        page={0}
+        rowsPerPage={15}
+        selectedRows={[]}
+        selectRowUpdate={selectRowUpdate}
+        highlightedRows={[1, 2, 3]}
+        expandedRows={[]}
+        toggleExpandRow={toggleExpandRow}
+        options={options}
+        searchText={''}
+        filterList={[]}
+      />,
+    ).dive();
+
+    const instance = shallowWrapper.instance();
+    const actualResult = instance.isRowHighlighted(5);
+
+    assert.strictEqual(actualResult, false);
   });
 
   it('should gather selected row data when clicking row with selectableRowsOnClick=true.', () => {
@@ -217,6 +252,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -250,6 +286,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -289,6 +326,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -321,6 +359,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -352,6 +391,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -369,6 +409,70 @@ describe('<TableBody />', function() {
     assert(options.onRowClick.calledWith(data[2], { rowIndex: 2, dataIndex: 2 }));
   });
 
+  it('should call onRowMouseEnter when mouse enters Row', () => {
+    const options = { selectableRows: true, onRowMouseEnter: spy() };
+    const selectRowUpdate = stub();
+    const toggleExpandRow = () => {};
+
+    const mountWrapper = mount(
+      <TableBody
+        data={displayData}
+        count={displayData.length}
+        columns={columns}
+        page={0}
+        rowsPerPage={10}
+        selectedRows={[]}
+        selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
+        expandedRows={[]}
+        toggleExpandRow={toggleExpandRow}
+        options={options}
+        searchText={''}
+        filterList={[]}
+      />,
+    );
+
+    mountWrapper
+      .find('#MUIDataTableBodyRow-2')
+      .first()
+      .simulate('mouseenter');
+
+    assert.strictEqual(options.onRowMouseEnter.callCount, 1);
+    assert(options.onRowMouseEnter.calledWith(data[2], { rowIndex: 2, dataIndex: 2 }));
+  });
+
+  it('should call onRowMouseLeave when mouse leaves Row', () => {
+    const options = { selectableRows: true, onRowMouseLeave: spy() };
+    const selectRowUpdate = stub();
+    const toggleExpandRow = () => {};
+
+    const mountWrapper = mount(
+      <TableBody
+        data={displayData}
+        count={displayData.length}
+        columns={columns}
+        page={0}
+        rowsPerPage={10}
+        selectedRows={[]}
+        selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
+        expandedRows={[]}
+        toggleExpandRow={toggleExpandRow}
+        options={options}
+        searchText={''}
+        filterList={[]}
+      />,
+    );
+
+    mountWrapper
+      .find('#MUIDataTableBodyRow-2')
+      .first()
+      .simulate('mouseleave');
+
+    assert.strictEqual(options.onRowMouseLeave.callCount, 1);
+    assert(options.onRowMouseLeave.calledWith(data[2], { rowIndex: 2, dataIndex: 2 }));
+  });
+
   it("should add custom props to rows if 'setRowProps' provided", () => {
     const options = { setRowProps: stub().returns({ className: 'testClass' }) };
     const selectRowUpdate = stub();
@@ -383,6 +487,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}
@@ -415,6 +520,7 @@ describe('<TableBody />', function() {
         rowsPerPage={10}
         selectedRows={[]}
         selectRowUpdate={selectRowUpdate}
+        highlightedRows={[]}
         expandedRows={[]}
         toggleExpandRow={toggleExpandRow}
         options={options}


### PR DESCRIPTION
This branch includes 3 additional properties that enable applications to synchronize highlights across multiple views (e.g., a mui-datatable and a bar graph).  Includes a examples/brushing/index.js to demonstrate how to

1. Highlight rows based on application state

1. Hook up mouse events used to update application state