### PR TITLE
fixes "Uncaught TypeError: prevState.selectedRows is not iterable"

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -949,7 +949,7 @@ class MUIDataTable extends React.Component {
             return arr;
           }, []);
 
-          let newRows = [...prevState.selectedRows, ...selectedRows];
+          let newRows = [...prevState.selectedRows.data, ...selectedRows];
           let selectedMap = buildMap(newRows);
 
           if (isDeselect) {


### PR DESCRIPTION
```
MUIDataTable.js:952 Uncaught TypeError: prevState.selectedRows is not iterable
    at MUIDataTable.setState.prevState (MUIDataTable.js:952)
```