### PR TITLE
Allow derived column state to be rebuilt on prop change

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -351,11 +351,6 @@ class MUIDataTable extends React.Component {
     let filterData = [];
     let filterList = [];
 
-    if (this.state.columns.length && isEqual(this.rawColumns(newColumns), this.rawColumns(this.props.columns))) {
-      const { columns, filterList, filterData } = this.state;
-      return { columns, filterList, filterData };
-    }
-
     newColumns.forEach((column, colIndex) => {
       let columnOptions = {
         display: 'true',


### PR DESCRIPTION
Attempt at a quick fix for https://github.com/gregnb/mui-datatables/issues/643.

There is at least one open PR that also incorporates something similar, but there's more going on, and I've been suspicious that this condition is needed for a while, so I want to try this as a hotfix and get community feedback incorporating other changes.