### PR TITLE
Fixing page out of bounds issue

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -205,16 +205,17 @@ class MUIDataTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    // When search text or data changes, we need to reset page
+    if (this.props.options.searchText !== prevProps.options.searchText ||
+        this.props.data !== prevProps.data) {
+      this.setState({ page: 0 });
+    }
+
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
         this.setTableAction('propsUpdate');
       });
       this.updateOptions(this.props);
-    }
-
-    if (this.props.options.searchText !== prevProps.options.searchText) {
-      // When we have a search, we must reset page to view it
-      this.setState({ page: 0 });
     }
 
     if (this.options.resizableColumns) {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -205,11 +205,11 @@ class MUIDataTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    this.checkPageOutOfBounds();
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
         this.setTableAction('propsUpdate');
       });
-      this.checkPageOutOfBounds();
       this.updateOptions(this.props);
     }
 
@@ -227,7 +227,7 @@ class MUIDataTable extends React.Component {
   checkPageOutOfBounds() {
     const lastPage = Math.max(0, Math.ceil(this.props.data.length / this.options.rowsPerPage) - 1);
     if (this.state.page > lastPage) {
-        this.setState({page: lastPage});
+        this.setState({ page: lastPage });
     }
   }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -209,6 +209,7 @@ class MUIDataTable extends React.Component {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
         this.setTableAction('propsUpdate');
       });
+      this.checkPageOutOfBounds();
       this.updateOptions(this.props);
     }
 
@@ -220,6 +221,13 @@ class MUIDataTable extends React.Component {
     if (this.options.resizableColumns) {
       this.setHeadResizeable(this.headCellRefs, this.tableRef);
       this.updateDividers();
+    }
+  }
+
+  checkPageOutOfBounds() {
+    const lastPage = Math.max(0, Math.ceil(this.props.data.length / this.options.rowsPerPage) - 1);
+    if (this.state.page > lastPage) {
+        this.setState({page: lastPage});
     }
   }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -206,6 +206,7 @@ class MUIDataTable extends React.Component {
 
   componentDidUpdate(prevProps) {
     this.checkPageOutOfBounds();
+
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
         this.setTableAction('propsUpdate');

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -205,17 +205,16 @@ class MUIDataTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    // When search text or data changes, we need to reset page
-    if (this.props.options.searchText !== prevProps.options.searchText ||
-        this.props.data !== prevProps.data) {
-      this.setState({ page: 0 });
-    }
-
     if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
       this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
         this.setTableAction('propsUpdate');
       });
       this.updateOptions(this.props);
+    }
+
+    if (this.props.options.searchText !== prevProps.options.searchText) {
+      // When we have a search, we must reset page to view it
+      this.setState({ page: 0 });
     }
 
     if (this.options.resizableColumns) {

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -336,6 +336,26 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(state.filterData, expectedResult);
   });
 
+  it('should check for page out of bounds and move to last available page if necessary', () => {
+    const pagesOfData = Array.from({length: 100}, () => ['string1', 'string2', 'string3', 'string4']);
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={pagesOfData} />);
+    const table = shallowWrapper.dive();
+    const instance = table.instance();
+
+    instance.changePage(7);
+
+    assert.strictEqual(instance.state.page, 7);
+
+    const prevProps = shallowWrapper.props();
+    instance.props = {
+      ...instance.props,
+      data: pagesOfData.slice(0, 45)
+    };
+    instance.componentDidUpdate(prevProps);
+
+    assert.strictEqual(instance.state.page, 4);
+  });
+
   it('should correctly build internal rowsPerPage when provided in options', () => {
     const options = {
       rowsPerPage: 20,


### PR DESCRIPTION
Recreation Steps to produce bug:
- Load table with several pages of data
- Navigate to the last page
- Remove a large portion of the data
- The table component will throw an error and wreck your site

Resolution:
When `props.data` changes, we added a check to make sure the current page in state is not beyond the last available page. If necessary, the current page is set to the new last page.