### PR TITLE
Fix download filtered data only

### DIFF
--- a/examples/csv-export/index.js
+++ b/examples/csv-export/index.js
@@ -61,6 +61,10 @@ class Example extends React.Component {
       downloadOptions: {
           filename: 'excel-format.csv',
           separator: ';',
+          filterOptions: {
+            useDisplayedColumnsOnly: true,
+            useDisplayedRowsOnly: true,
+          }
       },
       onRowsSelect: (rowsSelected, allRows) => {
         console.log(rowsSelected, allRows);

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -147,6 +147,10 @@ class MUIDataTable extends React.Component {
       downloadOptions: PropTypes.shape({
         filename: PropTypes.string,
         separator: PropTypes.string,
+        filterOptions: PropTypes.shape({
+          useDisplayedColumnsOnly: PropTypes.bool,
+          useDisplayedRowsOnly: PropTypes.bool
+        })
       }),
       onDownload: PropTypes.func,
     }),

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -95,8 +95,26 @@ class TableToolbar extends React.Component {
   }
 
   handleCSVDownload = () => {
-    const { data, columns, options } = this.props;
-    createCSVDownload(columns, data, options);
+    const { data, displayData, columns, options } = this.props;
+    let dataToDownload = data;
+    let columnsToDownload = columns;
+
+    if (options.downloadOptions && options.downloadOptions.filterOptions) {
+      // check rows first:
+      if (options.downloadOptions.filterOptions.useDisplayedRowsOnly) {
+        dataToDownload = displayData;
+      }
+      // now, check columns:
+      if (options.downloadOptions.filterOptions.useDisplayedColumnsOnly) {
+        columnsToDownload = columns.filter((_, index) => _.display==='true');
+
+        dataToDownload = dataToDownload.map(row => {
+          row.data = row.data.filter((_, index) => columns[index].display==='true');
+          return row;
+        });
+      }
+    }
+    createCSVDownload(columnsToDownload, dataToDownload, options);
   };
 
   setActiveIcon = iconName => {


### PR DESCRIPTION
Based on [#440](https://github.com/gregnb/mui-datatables/pull/440) I have added support to the optional parameters to let users define when they want to export everything or only rows and columns filtered.