### PR TITLE
Issue warning instead of throwing an error

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -55,13 +55,7 @@ class TableBody extends React.Component {
     const toIndex = Math.min(count, (page + 1) * rowsPerPage);
 
     if (page > totalPages && totalPages !== 0) {
-      throw new Error(
-        'Provided options.page of `' +
-          page +
-          '` is greater than the total available page length of `' +
-          totalPages +
-          '`',
-      );
+      console.warn('Current page is out of range.');
     }
 
     for (let rowIndex = fromIndex; rowIndex < count && rowIndex < toIndex; rowIndex++) {


### PR DESCRIPTION
Closes https://github.com/gregnb/mui-datatables/issues/718.

We have a means to clean up the page out of bounds issue elsewhere, so this error is no longer needed and was causing breakage in certain circumstances.