### PR TITLE
Add table option: show expanded row(s) by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The component accepts the following props:
 |**`expandableRows`**|boolean|false|Enable/disable expandable rows
 |**`expandableRowsOnClick`**|boolean|false|Enable/disable expand trigger when row is clicked. When False, only expand icon will trigger this action.
 |**`renderExpandableRow`**|function||Render expandable row. `function(rowData, rowMeta) => React Component`
+|**`isRowDefaultExpanded`**|function||Should row be expanded by default. `function(rowIndex, rowData) => boolean`
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`

--- a/examples/expandable-rows/index.js
+++ b/examples/expandable-rows/index.js
@@ -91,7 +91,8 @@ class Example extends React.Component {
             </TableCell>
           </TableRow>
         );
-      }
+      },
+      isRowDefaultExpanded: (index, data) => index === 0
     };
 
     return (

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -124,6 +124,7 @@ class MUIDataTable extends React.Component {
       expandableRows: PropTypes.bool,
       expandableRowsOnClick: PropTypes.bool,
       renderExpandableRow: PropTypes.func,
+      isRowDefaultExpanded: PropTypes.func,
       customToolbar: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
       customToolbarSelect: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
       customFooter: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
@@ -294,6 +295,9 @@ class MUIDataTable extends React.Component {
     }
     if (options.expandableRows && options.renderExpandableRow === undefined) {
       throw Error('renderExpandableRow must be provided when using expandableRows option');
+    }
+    if (options.isRowDefaultExpanded && options.isRowDefaultExpanded === undefined) {
+      throw Error('isRowDefaultExpanded must be provided when using isRowDefaultExpanded option');
     }
     if (this.props.options.filterList) {
       console.error(
@@ -509,6 +513,7 @@ class MUIDataTable extends React.Component {
       const sortedData = this.sortTable(tableData, sortIndex, sortDirection);
       tableData = sortedData.data;
     }
+    this.isRowDefaultExpanded(tableData);
     /* set source data and display Data set source set */
     this.setState(
       prevState => ({
@@ -942,6 +947,29 @@ class MUIDataTable extends React.Component {
       },
     );
   };
+
+  isRowDefaultExpanded(tableData) {
+    const { isRowDefaultExpanded } = this.props.options;
+    if (!isRowDefaultExpanded) {
+      return;
+    }
+
+    const rowsToExpand = tableData
+      .filter(({ index, data }) => isRowDefaultExpanded(index, data))
+      .map(({index }) => ({index, dataIndex: index }));
+
+    this.setState(
+      {
+        expandedRows: {
+          lookup: buildMap(rowsToExpand),
+          data: rowsToExpand
+        }
+      },
+      () => {
+        this.setTableAction('expandAllRows');
+      }
+    );
+  }
 
   selectRowUpdate = (type, value) => {
     // safety check

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -949,6 +949,36 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
   });
 
+  it('should render expandable rows, depending on external callback', () => {
+    const isRowDefaultExpanded = () => true;
+    const options = { isRowDefaultExpanded };
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);
+    const table = shallowWrapper.dive();
+    const instance = table.instance();
+    const expected = {
+      lookup: { '0': true, '1': true, '2': true, '3': true },
+      data:
+        [ { index: 0, dataIndex: 0 },
+          { index: 1, dataIndex: 1 },
+          { index: 2, dataIndex: 2 },
+          { index: 3, dataIndex: 3 } ] };
+
+    assert.deepEqual(instance.state.expandedRows, expected);
+  });
+
+  it('should render some expandable rows, depending on external callback', () => {
+    const isRowDefaultExpanded = index => index === 1;
+    const options = { isRowDefaultExpanded };
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);
+    const table = shallowWrapper.dive();
+    const instance = table.instance();
+    const expected = {
+      lookup: { '1': true },
+      data: [ { index: 1, dataIndex: 1 } ] };
+
+    assert.deepEqual(instance.state.expandedRows, expected);
+  });
+
   it('should skip client side filtering if server side filtering is enabled', () => {
     const options = { filterType: 'textField', serverSide: true };
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);


### PR DESCRIPTION
Add option to render rows expanded by default.

There's some scenarios, specifically for my employer current needs, to sometimes have a few rows, expanded by default, when the data is rendered, while still have the option to toggle it.

This PR is first attempt to try and add that behaviour. 
There's an optional `isRowDefaultExpanded` function, that will determine weather the row should expanded or not. 


Related with: #433 , #735 