### PR TITLE
Fix issue with display filter on IE11

### DIFF
--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -90,7 +90,7 @@ export const defaultFilterStyles = theme => ({
     justifyContent: 'space-between',
   },
   selectFormControl: {
-    flex: '1 1 calc(50% - 24px)',
+    flex: '1 1 auto',
   },
   /* textField */
   textFieldRoot: {
@@ -101,7 +101,7 @@ export const defaultFilterStyles = theme => ({
     width: '100%',
   },
   textFieldFormControl: {
-    flex: '1 1 calc(50% - 24px)',
+    flex: '1 1 auto',
   },
 });
 


### PR DESCRIPTION
There is a minor display issue with the filter component on IE11.
Please see the screenshot -->

**_Before:_**

<img width="508" alt="before" src="https://user-images.githubusercontent.com/4227421/62327233-a988d100-b475-11e9-82c2-3905aefdced4.png">

**_After:_**

<img width="483" alt="after" src="https://user-images.githubusercontent.com/4227421/62327257-bf969180-b475-11e9-9d63-6a84ee241652.png">

