### PR TITLE
Added options parameter to customFooter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The component accepts the following props:
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
-|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => string`&#124;` React Component`
+|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, `[`textLabels: object`](https://github.com/gregnb/mui-datatables/blob/master/src/textLabels.js)`) => string`&#124;` React Component` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The component accepts the following props:
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
-|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage) => string`&#124;` React Component`
+|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, options) => string`&#124;` React Component`
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The component accepts the following props:
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
-|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, options) => string`&#124;` React Component`
+|**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => string`&#124;` React Component`
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`

--- a/examples/customize-footer/CustomFooter.js
+++ b/examples/customize-footer/CustomFooter.js
@@ -19,8 +19,7 @@ class CustomFooter extends React.Component {
   };
 
   render() {
-    const { count, classes, options, rowsPerPage, page } = this.props;
-    const textLabels = options.textLabels.pagination;
+    const { count, classes, textLabels, rowsPerPage, page } = this.props;
 
     const footerStyle = {
       display:'flex', 
@@ -47,7 +46,7 @@ class CustomFooter extends React.Component {
               nextIconButtonProps={{
                 'aria-label': textLabels.next,
               }}
-              rowsPerPageOptions={options.rowsPerPageOptions}
+              rowsPerPageOptions={[10,20,100]}
               onChangePage={this.handlePageChange}
               onChangeRowsPerPage={this.handleRowChange}
             />

--- a/examples/customize-footer/CustomFooter.js
+++ b/examples/customize-footer/CustomFooter.js
@@ -2,6 +2,7 @@ import React from "react";
 import TableFooter from "@material-ui/core/TableFooter";
 import TableRow from "@material-ui/core/TableRow";
 import TableCell from "@material-ui/core/TableCell";
+import MuiTablePagination from "@material-ui/core/TablePagination";
 import { withStyles } from "@material-ui/core/styles";
 
 const defaultFooterStyles = {
@@ -9,17 +10,64 @@ const defaultFooterStyles = {
 
 class CustomFooter extends React.Component {
 
+  handleRowChange = event => {
+    this.props.changeRowsPerPage(event.target.value);
+  };
+
+  handlePageChange = (_, page) => {
+    const { options } = this.props;
+    this.props.changePage(page);
+  };
+
   render() {
-    const { classes } = this.props;
+    const { count, classes, options, rowsPerPage, page } = this.props;
+    const textLabels = options.textLabels.pagination;
+
+    const footerStyle = {
+      display:'flex', 
+      justifyContent: 'flex-end',
+      padding: '0px 24px 0px 24px'
+    };
 
     return (
-    <TableFooter>
-      <TableRow>
-        <TableCell>
-          some content
-        </TableCell>
-      </TableRow>
-    </TableFooter>
+      <TableFooter>
+        <TableRow>
+          <TableCell style={footerStyle} colSpan={1000}>
+            <button>Custom Option</button>
+          
+            <MuiTablePagination
+              component="div"
+              count={count}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              labelRowsPerPage={textLabels.rowsPerPage}
+              labelDisplayedRows={({ from, to, count }) => `${from}-${to} ${textLabels.displayRows} ${count}`}
+              backIconButtonProps={{
+                id: 'pagination-back',
+                'data-testid': 'pagination-back',
+                'aria-label': textLabels.previous,
+              }}
+              nextIconButtonProps={{
+                id: 'pagination-next',
+                'data-testid': 'pagination-next',
+                'aria-label': textLabels.next,
+              }}
+              SelectProps={{
+                id: 'pagination-input',
+                SelectDisplayProps: { id: 'pagination-rows', 'data-testid': 'pagination-rows' },
+                MenuProps: {
+                  id: 'pagination-menu',
+                  'data-testid': 'pagination-menu',
+                  MenuListProps: { id: 'pagination-menu-list', 'data-testid': 'pagination-menu-list' },
+                },
+              }}
+              rowsPerPageOptions={options.rowsPerPageOptions}
+              onChangePage={this.handlePageChange}
+              onChangeRowsPerPage={this.handleRowChange}
+            />
+          </TableCell>
+        </TableRow>
+      </TableFooter>
     );
   }
 

--- a/examples/customize-footer/CustomFooter.js
+++ b/examples/customize-footer/CustomFooter.js
@@ -15,7 +15,6 @@ class CustomFooter extends React.Component {
   };
 
   handlePageChange = (_, page) => {
-    const { options } = this.props;
     this.props.changePage(page);
   };
 
@@ -43,23 +42,10 @@ class CustomFooter extends React.Component {
               labelRowsPerPage={textLabels.rowsPerPage}
               labelDisplayedRows={({ from, to, count }) => `${from}-${to} ${textLabels.displayRows} ${count}`}
               backIconButtonProps={{
-                id: 'pagination-back',
-                'data-testid': 'pagination-back',
                 'aria-label': textLabels.previous,
               }}
               nextIconButtonProps={{
-                id: 'pagination-next',
-                'data-testid': 'pagination-next',
                 'aria-label': textLabels.next,
-              }}
-              SelectProps={{
-                id: 'pagination-input',
-                SelectDisplayProps: { id: 'pagination-rows', 'data-testid': 'pagination-rows' },
-                MenuProps: {
-                  id: 'pagination-menu',
-                  'data-testid': 'pagination-menu',
-                  MenuListProps: { id: 'pagination-menu-list', 'data-testid': 'pagination-menu-list' },
-                },
               }}
               rowsPerPageOptions={options.rowsPerPageOptions}
               onChangePage={this.handlePageChange}

--- a/examples/customize-footer/index.js
+++ b/examples/customize-footer/index.js
@@ -48,9 +48,15 @@ class Example extends React.Component {
       filterType: 'dropdown',
       responsive: 'stacked',
       rowsPerPage: 10,
-      customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage) => {
+      customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, options) => {
         return (  
-          <CustomFooter changePage={changePage} count={count} />
+          <CustomFooter 
+            count={count} 
+            page={page} 
+            rowsPerPage={rowsPerPage} 
+            changeRowsPerPage={changeRowsPerPage} 
+            changePage={changePage} 
+            options={options} />
         );
       }
     };

--- a/examples/customize-footer/index.js
+++ b/examples/customize-footer/index.js
@@ -44,11 +44,10 @@ class Example extends React.Component {
 
     const options = {
       filter: true,
-      selectableRows: true,
       filterType: 'dropdown',
       responsive: 'stacked',
       rowsPerPage: 10,
-      customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, options) => {
+      customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => {
         return (  
           <CustomFooter 
             count={count} 
@@ -56,7 +55,7 @@ class Example extends React.Component {
             rowsPerPage={rowsPerPage} 
             changeRowsPerPage={changeRowsPerPage} 
             changePage={changePage} 
-            options={options} />
+            textLabels={textLabels} />
         );
       }
     };

--- a/src/components/TableFooter.js
+++ b/src/components/TableFooter.js
@@ -16,7 +16,7 @@ class TableFooter extends React.Component {
     return (
       <MuiTable>
         {options.customFooter
-          ? options.customFooter(rowCount, page, rowsPerPage, changeRowsPerPage, changePage, options)
+          ? options.customFooter(rowCount, page, rowsPerPage, changeRowsPerPage, changePage, options.textLabels.pagination)
           : options.pagination && (
               <TablePagination
                 count={rowCount}

--- a/src/components/TableFooter.js
+++ b/src/components/TableFooter.js
@@ -16,7 +16,7 @@ class TableFooter extends React.Component {
     return (
       <MuiTable>
         {options.customFooter
-          ? options.customFooter(rowCount, page, rowsPerPage, changeRowsPerPage, changePage)
+          ? options.customFooter(rowCount, page, rowsPerPage, changeRowsPerPage, changePage, options)
           : options.pagination && (
               <TablePagination
                 count={rowCount}

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -44,7 +44,6 @@ class TablePagination extends React.Component {
   };
 
   handlePageChange = (_, page) => {
-    const { options } = this.props;
     this.props.changePage(page);
   };
 


### PR DESCRIPTION
Fix for https://github.com/gregnb/mui-datatables/issues/789

I've updated the customFooter callback to also take in the options parameter. With this parameter, one can more easily re-create the table pagination. I've also fleshed out the customize-footer example by showing how the Material UI TablePagination component can be used inside of the footer with other custom options.