### PR TITLE
Fix to make tests compatible with Material UI v3 and v4

### DIFF
--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -75,12 +75,12 @@ describe('<MUIDataTable />', function() {
 
   it('should render a table', () => {
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />);
-    assert.strictEqual(
+    assert.include(
+      ['Paper', 'ForwardRef(Paper)'],
       shallowWrapper
         .dive()
         .dive()
         .name(),
-      'Paper',
     );
   });
 

--- a/test/setup-mocha-env.js
+++ b/test/setup-mocha-env.js
@@ -54,6 +54,8 @@ function setupDom() {
 
   global.window.cancelAnimationFrame = () => {};
   global.getComputedStyle = global.window.getComputedStyle;
+  global.HTMLInputElement = global.window.HTMLInputElement;
+  global.Element = global.window.Element;
 
   Object.defineProperty(global.window.URL, 'createObjectURL', { value: () => {} });
   global.Blob = () => '';


### PR DESCRIPTION
I've made 2 small tweaks that allow the tests to work on both Material UI v3 and v4. In this PR I only change the tests and not the package.json or package-lock.json files (more on that below). Steps to test:

1. Do everything as usual, run the tests and see that they still work properly with v3.
2. Remove package-lock.json and ./node_modules
3. Update package.json: Change @materual-ui/core version to "4.3.0", react to "16.9.0" and react-dom to "16.9.0".
4. run "npm i".
5. run "npm run test" and see that the tests also work and pass with v4.

I didn't update package.json and package-lock.json since I figure it's in the cards to do that later down the road - though I'll note that I've been using the table with MUI v4 and I haven't seen any issues, though I know there are a few small things, ex: https://github.com/gregnb/mui-datatables/issues/595 https://github.com/gregnb/mui-datatables/issues/676).

Let me know if I'm overwhelming you with PRs, I'm going to be pretty busy after this coming Friday, so this will most likely be my last one for a while.

Anyway, while doing one of my other PRs I noticed the tests didn't work in MUI v4. I decided to look into it, and it appears to be because the MUI folks are doing instanceOf checks for HTMLInputElement [1] and Element [2], which the tests look for on the global object (since the MUI code assumes they're in the global scope). Attaching them to the global object allows 24 of the failing tests to pass when run under Material v4 (and to still work under v3).

I fixed the last remaining test by allowing "ForwardRef(Paper)" to also be a valid value. I toyed around with the dive().name calls, and it looks like something just changed under the hood to make it so it became "ForwardRef(Paper)" in newer versions of the framework. 

[1] https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Popover/Popover.js#L144 
[2] https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputBase/InputBase.js#L197