### PR TITLE
Silence deprecation warning by using the unsafe API

### DIFF
--- a/docs/utils/withRoot.js
+++ b/docs/utils/withRoot.js
@@ -5,7 +5,7 @@ import getPageContext from './getPageContext';
 
 function withRoot(Component) {
   class WithRoot extends React.Component {
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.pageContext = this.props.pageContext || getPageContext();
     }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -208,7 +208,7 @@ class MUIDataTable extends React.Component {
     this.updateDividers = () => {};
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.initializeTable(this.props);
   }
 

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -8,7 +8,7 @@ class Popover extends React.Component {
     open: false,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.anchorEl = null;
   }
 


### PR DESCRIPTION
Will remove this lifecycle entirely in a later release

Closes https://github.com/gregnb/mui-datatables/issues/844

- [x] Find and change other uses of deprecated lifecycles to unsafe