### PR TITLE
Feature/issue 759 responsive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![dependencies Status](https://david-dm.org/gregnb/mui-datatables/status.svg)](https://david-dm.org/gregnb/mui-datatables)
 [![npm version](https://badge.fury.io/js/mui-datatables.svg)](https://badge.fury.io/js/mui-datatables)
 
-MUI-Datatables is a data tables component built on [Material-UI](https://www.material-ui.com).  It comes with features like filtering, resizable + view/hide columns, search, export to CSV download, printing, selectable rows, expandable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are two responsive modes "stacked" and "scroll" for mobile/tablet devices.
+MUI-Datatables is a data tables component built on [Material-UI](https://www.material-ui.com).  It comes with features like filtering, resizable + view/hide columns, search, export to CSV download, printing, selectable rows, expandable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are three responsive modes "stacked", "scrollMaxHeight", and "scrollFullHeight" for mobile/tablet devices.
 
 <div align="center">
 	<img src="https://user-images.githubusercontent.com/19170080/38026128-eac9d506-3258-11e8-92a7-b0d06e5faa82.gif" />
@@ -156,7 +156,7 @@ The component accepts the following props:
 |**`customSearchRender `**|function||Render a custom table search. `customSearchRender(searchText: string, handleSearch, hideSearch, options) => React Component`
 |**`elevation`**|number|4|Shadow depth applied to Paper component
 |**`caseSensitive `**|boolean|false|Enable/disable case sensitivity for search
-|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scroll'
+|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage)
 |**`rowsPerPage`**|number|10|Number of rows allowed per page
 |**`rowsPerPageOptions`**|array|[10,15,100]|Options to provide in pagination for number of rows a user can select
 |**`rowHover`**|boolean|true|Enable/disable hover style over rows

--- a/examples/array-value-columns/index.js
+++ b/examples/array-value-columns/index.js
@@ -94,7 +94,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
     };
 
     return (

--- a/examples/component/index.js
+++ b/examples/component/index.js
@@ -126,7 +126,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll'
+      responsive: 'scrollMaxHeight'
     };
 
     return (

--- a/examples/customize-filter/index.js
+++ b/examples/customize-filter/index.js
@@ -141,7 +141,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
     };
 
     return (

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -71,7 +71,7 @@ function Example() {
       ]}
       options={{
         selectableRows: "none",
-        responsive: "scroll",
+        responsive: "scrollMaxHeight",
         customRowRender: data => {
           const [ name, cardNumber, cvc, expiry ] = data;
           

--- a/examples/expandable-rows/index.js
+++ b/examples/expandable-rows/index.js
@@ -79,7 +79,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
       expandableRows: true,
       expandableRowsOnClick: true,
       rowsExpanded: [0, 2, 3],

--- a/examples/fixed-header/index.js
+++ b/examples/fixed-header/index.js
@@ -78,7 +78,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
       fixedHeader: true
     };
 

--- a/examples/hide-columns-print/index.js
+++ b/examples/hide-columns-print/index.js
@@ -81,7 +81,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
     };
 
     return (

--- a/examples/on-download/index.js
+++ b/examples/on-download/index.js
@@ -103,7 +103,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
       onDownload: (buildHead, buildBody, columns, data) =>
         buildHead(headerNames) +
         buildBody(

--- a/examples/on-table-init/index.js
+++ b/examples/on-table-init/index.js
@@ -67,7 +67,7 @@ class Example extends React.Component {
     filter: true,
     selectableRows: true,
     filterType: 'dropdown',
-    responsive: 'scroll',
+    responsive: 'scrollMaxHeight',
     rowsPerPage: 10,
     download: false, // hide csv download option
     onTableInit: this.handleTableInit,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -31,6 +31,18 @@ const defaultTableStyles = theme => ({
     height: '100%',
     maxHeight: '499px',
   },
+  responsiveScrollMaxHeight: {
+    overflowX: 'auto',
+    overflow: 'auto',
+    height: '100%',
+    maxHeight: '499px',
+  },
+  responsiveScrollFullHeight: {
+    overflowX: 'auto',
+    overflow: 'auto',
+    height: '100%',
+    maxHeight: 'none',
+  },
   responsiveStacked: {
     overflowX: 'auto',
     overflow: 'auto',
@@ -117,7 +129,7 @@ class MUIDataTable extends React.Component {
     ).isRequired,
     /** Options used to describe table */
     options: PropTypes.shape({
-      responsive: PropTypes.oneOf(['stacked', 'scroll']),
+      responsive: PropTypes.oneOf(['stacked', 'scrollMaxHeight', 'scrollFullHeight']),
       filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
       textLabels: PropTypes.object,
       pagination: PropTypes.bool,
@@ -295,8 +307,11 @@ class MUIDataTable extends React.Component {
     if (props.options.rowsPerPageOptions) {
       this.options.rowsPerPageOptions = props.options.rowsPerPageOptions;
     }
-    if (['scroll', 'stacked'].indexOf(this.options.responsive) === -1) {
-      console.error('Invalid option value for responsive. Please use string option: stacked | scroll');
+    if (['scrollMaxHeight', 'scrollFullHeight', 'stacked'].indexOf(this.options.responsive) === -1) {
+      console.error('Invalid option value for responsive. Please use string option: scrollMaxHeight | scrollFullHeight | stacked');
+    }
+    if (this.options.responsive === 'scroll') {
+      console.error('This option has been deprecated. It is being replaced by scrollMaxHeight');
     }
   }
 
@@ -1179,6 +1194,23 @@ class MUIDataTable extends React.Component {
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
     const showToolbar = hasToolbarItem(this.options, title);
     const columnNames = columns.map(column => ({ name: column.name, filterType: column.filterType }));
+    let responsiveClass;
+
+    switch (this.options.responsive) {
+      // DEPRECATED: This options is beign transitioned to `responsiveScrollMaxHeight`
+      case 'scroll':
+        responsiveClass = classes.responsiveScroll;
+        break;
+      case 'scrollMaxHeight':
+        responsiveClass = classes.responsiveScrollMaxHeight;
+        break;
+      case 'scrollFullHeight':
+        responsiveClass = classes.responsiveFullHeight;
+        break;
+      case 'stacked':
+        responsiveClass = classes.responsiveStacked;
+        break;
+    }
 
     return (
       <Paper
@@ -1224,7 +1256,7 @@ class MUIDataTable extends React.Component {
         />
         <div
           style={{ position: 'relative' }}
-          className={this.options.responsive === 'scroll' ? classes.responsiveScroll : classes.responsiveStacked}>
+          className={responsiveClass}>
           {this.options.resizableColumns && (
             <TableResize
               key={rowCount}

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -1264,7 +1264,7 @@ describe('<MUIDataTable />', function() {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
     };
 
     it('should correctly filter array data', () => {
@@ -1312,7 +1312,7 @@ describe('<MUIDataTable />', function() {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scroll',
+      responsive: 'scrollMaxHeight',
     };
 
     it('should correctly filter data when no array data is present', () => {


### PR DESCRIPTION
Closes https://github.com/gregnb/mui-datatables/issues/759, https://github.com/gregnb/mui-datatables/issues/580, and https://github.com/gregnb/mui-datatables/issues/234#issuecomment-463101548.

- adds responsive option called `scrollFullHeight` which allows display of all rows (from a given page) in the browser without a max height
- responsive `scroll` option has been deprecated and is being replaced with `scrollMaxHeight`