### PR TITLE
Fix for #869

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The component accepts the following props:
 |**`onChangeRowsPerPage`**|function||Callback function that triggers when the number of rows per page has changed. `function(numberOfRows: number) => void`
 |**`onSearchChange`**|function||Callback function that triggers when the search text value has changed. `function(searchText: string) => void`
 |**`onSearchOpen`**|function||Callback function that triggers when the searchbox opens. `function() => void`
+|**`onSearchClose`**|function||Callback function that triggers when the searchbox closes. `function() => void`
 |**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array) => void`
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`
 |**`onColumnViewChange`**|function||Callback function that triggers when a column view has been changed. `function(changedColumn: string, action: string) => void`

--- a/examples/customize-search-render/CustomSearchRender.js
+++ b/examples/customize-search-render/CustomSearchRender.js
@@ -27,7 +27,7 @@ class CustomSearchRender extends React.Component {
     if (onSearchChange) {
       onSearchChange(event.target.value);
     }
-
+    
     this.props.onSearch(event.target.value);
   };
 

--- a/examples/customize-search-render/CustomSearchRender.js
+++ b/examples/customize-search-render/CustomSearchRender.js
@@ -22,12 +22,6 @@ const defaultSearchStyles = theme => ({
 
 class CustomSearchRender extends React.Component {
   handleTextChange = event => {
-    const { onSearchChange } = this.props.options;
-
-    if (onSearchChange) {
-      onSearchChange(event.target.value);
-    }
-    
     this.props.onSearch(event.target.value);
   };
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -897,6 +897,9 @@ class MUIDataTable extends React.Component {
       }),
       () => {
         this.setTableAction('search');
+        if (this.options.onSearchChange) {
+          this.options.onSearchChange(this.state.searchText);
+        }
       },
     );
   };

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -28,12 +28,6 @@ const defaultSearchStyles = theme => ({
 
 class TableSearch extends React.Component {
   handleTextChange = event => {
-    const { onSearchChange } = this.props.options;
-
-    if (onSearchChange) {
-      onSearchChange(event.target.value);
-    }
-
     this.props.onSearch(event.target.value);
   };
 

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -198,18 +198,12 @@ class TableToolbar extends React.Component {
     const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
     const { showSearch, searchText } = this.state;
 
-    // prevent a customSearchRender component from calling the onSearchChange callback
-    let optionsCopy = Object.assign({}, options);
-    optionsCopy.onSearchChange = function() {
-      console.warn('The onSearchChange callback no longer needs to be managed by a customSearch component.');
-    };
-
     return (
       <Toolbar className={classes.root} role={'toolbar'} aria-label={'Table Toolbar'}>
         <div className={classes.left}>
           {showSearch === true ? (
             options.customSearchRender ? (
-              options.customSearchRender(searchText, this.handleSearch, this.hideSearch, optionsCopy)
+              options.customSearchRender(searchText, this.handleSearch, this.hideSearch, options)
             ) : (
               <TableSearch
                 searchText={searchText}

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -139,6 +139,7 @@ class TableToolbar extends React.Component {
         nextVal = true;
       } else {
         const { onSearchClose } = this.props.options;
+        this.props.setTableAction('onSearchClose');
         if (onSearchClose) onSearchClose();
         nextVal = false;
       }
@@ -153,14 +154,15 @@ class TableToolbar extends React.Component {
   };
 
   showSearch = () => {
-    !!this.props.options.onSearchOpen && this.props.options.onSearchOpen();
     this.props.setTableAction('onSearchOpen');
+    !!this.props.options.onSearchOpen && this.props.options.onSearchOpen();
     return true;
   };
 
   hideSearch = () => {
     const { onSearchClose } = this.props.options;
 
+    this.props.setTableAction('onSearchClose');
     if (onSearchClose) onSearchClose();
     this.props.searchTextUpdate(null);
 
@@ -196,12 +198,18 @@ class TableToolbar extends React.Component {
     const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
     const { showSearch, searchText } = this.state;
 
+    // prevent a customSearchRender component from calling the onSearchChange callback
+    let optionsCopy = Object.assign({}, options);
+    optionsCopy.onSearchChange = function() {
+      console.warn('The onSearchChange callback no longer needs to be managed by a customSearch component.');
+    };
+
     return (
       <Toolbar className={classes.root} role={'toolbar'} aria-label={'Table Toolbar'}>
         <div className={classes.left}>
           {showSearch === true ? (
             options.customSearchRender ? (
-              options.customSearchRender(searchText, this.handleSearch, this.hideSearch, options)
+              options.customSearchRender(searchText, this.handleSearch, this.hideSearch, optionsCopy)
             ) : (
               <TableSearch
                 searchText={searchText}


### PR DESCRIPTION
https://github.com/gregnb/mui-datatables/issues/869

* Added documentation for onSearchClose and made a corresponding onTableChange event for it.
* Moved triggering of onSearchChange to MUIDatatable component so that it mirrors the "search" event. This also makes it so customSearch components don't have to manage this event.
* Made sure customSearch components can't double invoke this method if they're already setup to call it.

Quick view: https://codesandbox.io/s/github/patorjk/mui-datatables/tree/onSearchChange

Used this setup to follow event call order:

      onSearchOpen: () => {
        console.log('onSearchOpen');
      },
      onSearchClose: () => {
        console.log('onSearchClose');
      },
      onSearchChange: (txt) => {
        console.log('onSearchChange:'+txt);
      },
      onTableChange: (action, tableState) => {
        console.log("onTableChange: " + action + ', searchText:'+tableState.searchText);
      },