### PR TITLE
Fix for #873

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,10 +17,10 @@ function getCollatorComparator() {
 
 function sortCompare(order) {
   return (a, b) => {
-    if (a.data === null) a.data = '';
-    if (b.data === null) b.data = '';
+    var aData = (a.data === null || typeof a.data === 'undefined') ? '' : a.data;
+    var bData = (b.data === null || typeof b.data === 'undefined') ? '' : b.data;
     return (
-      (typeof a.data.localeCompare === 'function' ? a.data.localeCompare(b.data) : a.data - b.data) *
+      (typeof aData.localeCompare === 'function' ? aData.localeCompare(bData) : aData - bData) *
       (order === 'asc' ? 1 : -1)
     );
   };


### PR DESCRIPTION
https://github.com/gregnb/mui-datatables/issues/873

Quick view: https://codesandbox.io/s/github/patorjk/mui-datatables/tree/sortFail

For test, change customizeFilter example to:

```
import { FormGroup, FormLabel, TextField } from '@material-ui/core';
import React from 'react';
import ReactDOM from 'react-dom';
import MUIDataTable from '../../src';

class Example extends React.Component {
  render() {
    const data = [
      {
        foo: 1,
        bar: 2
      },
      {
        foo: 3
      }
    ];

    const columns = [
      {
        name: "foo"
      },
      {
        name: "bar"
      }
    ];

    var options = {
      responsive: "scroll"
    };

    return (
      <MUIDataTable title={'ACME Employee list - customizeFilter'} data={data} columns={columns} options={options} />
    );
  }
}

ReactDOM.render(<Example />, document.getElementById('app-root'));
```