### PR TITLE
No Pointer style cursor for table head when no hint or sorting

### DIFF
--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -27,10 +27,6 @@ const defaultHeadCellStyles = theme => ({
   data: {
     display: 'inline-block',
   },
-  noSortAction: {
-    display: 'flex',
-    verticalAlign: 'top',
-  },
   sortAction: {
     display: 'flex',
     verticalAlign: 'top',
@@ -165,7 +161,7 @@ class TableHeadCell extends React.Component {
             </span>
           </Tooltip>
         ) : (
-          <div className={hint ? classes.sortAction : classes.noSortAction}>
+          <div className={hint ? classes.sortAction : null}>
             {children}
             {hint && (
               <Tooltip

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -27,6 +27,10 @@ const defaultHeadCellStyles = theme => ({
   data: {
     display: 'inline-block',
   },
+  noSortAction: {
+    display: 'flex',
+    verticalAlign: 'top',
+  },
   sortAction: {
     display: 'flex',
     verticalAlign: 'top',
@@ -161,7 +165,7 @@ class TableHeadCell extends React.Component {
             </span>
           </Tooltip>
         ) : (
-          <div className={classes.sortAction}>
+          <div className={hint ? classes.sortAction : classes.noSortAction}>
             {children}
             {hint && (
               <Tooltip


### PR DESCRIPTION
With no sorting or a hint, the cursor still shows a pointer. I'm not saying this is the best solution, but I think the header shouldn't shouldn't show a pointer style of cursor when there is nothing to click on or additional behavior from hovering.