### PR TITLE
Fix crash on downloading an empty dataset as CSV

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import IconButton from '@material-ui/core/IconButton';
-import Tooltip from '@material-ui/core/Tooltip';
 import DownloadIcon from '@material-ui/icons/CloudDownload';
 import BuildIcon from '@material-ui/icons/Build'; // eslint-disable-line import/no-unresolved
 import CodeSnippet from '../utils/CodeSnippet';

--- a/docs/utils/layout.js
+++ b/docs/utils/layout.js
@@ -1,7 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import Head from 'next/head';
-import Typography from '@material-ui/core/Typography';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import MuiPopover from '@material-ui/core/Popover';
 import { findDOMNode } from 'react-dom';
 

--- a/src/components/TableFooter.js
+++ b/src/components/TableFooter.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import MuiTable from '@material-ui/core/Table';
-import TableHead from './TableHead';
 import TablePagination from './TablePagination';
-import { withStyles } from '@material-ui/core/styles';
 
 export const defaultFooterStyles = {};
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ function sortCompare(order) {
 
 function assembleCSV(columns, data, options) {
   const replaceDoubleQuoteInString = columnData =>
-  typeof columnData === 'string' ? columnData.replace(/\"/g, '""') : columnData;
+    typeof columnData === 'string' ? columnData.replace(/\"/g, '""') : columnData;
 
   const buildHead = columns => {
     return (
@@ -56,7 +56,7 @@ function assembleCSV(columns, data, options) {
             .map(columnData => replaceDoubleQuoteInString(columnData))
             .join('"' + options.downloadOptions.separator + '"') +
           '"\r\n',
-        "",
+        '',
       )
       .trim();
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,6 +66,11 @@ function assembleCSV(columns, data, options) {
     ? options.onDownload(buildHead, buildBody, columns, data)
     : `${CSVHead}${CSVBody}`.trim();
 
+  const downloadHasBeenAborted = csv === false;
+  if (downloadHasBeenAborted) {
+    return null;
+  }
+
   return csv;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,9 +26,9 @@ function sortCompare(order) {
   };
 }
 
-function createCSVDownload(columns, data, options) {
+function assembleCSV(columns, data, options) {
   const replaceDoubleQuoteInString = columnData =>
-    typeof columnData === 'string' ? columnData.replace(/\"/g, '""') : columnData;
+  typeof columnData === 'string' ? columnData.replace(/\"/g, '""') : columnData;
 
   const buildHead = columns => {
     return (
@@ -66,15 +66,15 @@ function createCSVDownload(columns, data, options) {
     ? options.onDownload(buildHead, buildBody, columns, data)
     : `${CSVHead}${CSVBody}`.trim();
 
-  if (options.onDownload && csv === false) {
-    return;
-  }
+  return csv;
+}
 
+function downloadCSV(csv, filename) {
   const blob = new Blob([csv], { type: 'text/csv' });
 
   /* taken from react-csv */
   if (navigator && navigator.msSaveOrOpenBlob) {
-    navigator.msSaveOrOpenBlob(blob, options.downloadOptions.filename);
+    navigator.msSaveOrOpenBlob(blob, filename);
   } else {
     const dataURI = `data:text/csv;charset=utf-8,${csv}`;
 
@@ -83,10 +83,17 @@ function createCSVDownload(columns, data, options) {
 
     let link = document.createElement('a');
     link.setAttribute('href', downloadURI);
-    link.setAttribute('download', options.downloadOptions.filename);
+    link.setAttribute('download', filename);
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+  }
+}
+
+function createCSVDownload(columns, data, options) {
+  const csv = assembleCSV(columns, data, options);
+  if (csv) {
+    downloadCSV(csv, options.downloadOptions.filename);
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,4 +97,4 @@ function createCSVDownload(columns, data, options) {
   }
 }
 
-export { buildMap, getCollatorComparator, sortCompare, createCSVDownload };
+export { buildMap, getCollatorComparator, sortCompare, createCSVDownload, assembleCSV };

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,7 +56,7 @@ function assembleCSV(columns, data, options) {
             .map(columnData => replaceDoubleQuoteInString(columnData))
             .join('"' + options.downloadOptions.separator + '"') +
           '"\r\n',
-        [],
+        "",
       )
       .trim();
   };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -51,5 +51,21 @@ describe('utils.js', () => {
         expect(csv).to.equal('"firstname";"lastname"');
       });
     });
+
+
+    describe("when switched off by returning `false` in `onDownload`", () => {
+      const dataSet = [['anton', 'abraham'], ['berta', 'buchel']].map(data => ({ data }));
+
+      const csv = assembleCSV(columns, dataSet, {
+        downloadOptions: {
+          separator: ";"
+        },
+        onDownload: () => false
+      });
+
+      it("returns null", () => {
+        expect(csv).to.be.null;
+      })
+    });
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,66 +1,55 @@
-import { assembleCSV } from "../src/utils";
-import { expect } from "chai";
+import { assembleCSV } from '../src/utils';
+import { expect } from 'chai';
 
-describe("utils", () => {
-  describe("assembleCSV", () => {
+describe('utils', () => {
+  describe('assembleCSV', () => {
     const options = {
       downloadOptions: {
-        separator: ";"
+        separator: ';',
       },
-      onDownload: null
-    }
+      onDownload: null,
+    };
 
     const columns = [
       {
-        name: "firstname",
-        download: true
+        name: 'firstname',
+        download: true,
       },
       {
-        name: "lastname",
-        download: true
-      }
+        name: 'lastname',
+        download: true,
+      },
     ];
 
-    describe("when given two rows", () => {
-      const dataSet = [
-        [ "anton", "abraham" ],
-        [ "berta", "buchel" ]
-      ].map(data => ({ data }));
+    describe('when given two rows', () => {
+      const dataSet = [['anton', 'abraham'], ['berta', 'buchel']].map(data => ({ data }));
 
       const csv = assembleCSV(columns, dataSet, options);
 
-      it("renders a two-record csv", () => {
-        expect(csv).to.equal(
-          '"firstname";"lastname"\r\n' +
-          '"anton";"abraham"\r\n' +
-          '"berta";"buchel"'
-        );
-      })
+      it('renders a two-record csv', () => {
+        expect(csv).to.equal('"firstname";"lastname"\r\n' + '"anton";"abraham"\r\n' + '"berta";"buchel"');
+      });
     });
 
-    describe("when given an empty dataset", () => {
+    describe('when given an empty dataset', () => {
       const columns = [
         {
-          name: "firstname",
-          download: true
+          name: 'firstname',
+          download: true,
         },
         {
-          name: "lastname",
-          download: true
-        }
+          name: 'lastname',
+          download: true,
+        },
       ];
 
       const dataSet = [];
 
-      const csv = assembleCSV(
-        columns,
-        dataSet,
-        options
-      );
+      const csv = assembleCSV(columns, dataSet, options);
 
-      it("returns an empty csv with header", () => {
+      it('returns an empty csv with header', () => {
         expect(csv).to.equal('"firstname";"lastname"');
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,7 @@
 import { assembleCSV } from '../src/utils';
 import { expect } from 'chai';
 
-describe('utils', () => {
+describe('utils.js', () => {
   describe('assembleCSV', () => {
     const options = {
       downloadOptions: {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,66 @@
+import { assembleCSV } from "../src/utils";
+import { expect } from "chai";
+
+describe("utils", () => {
+  describe("assembleCSV", () => {
+    const options = {
+      downloadOptions: {
+        separator: ";"
+      },
+      onDownload: null
+    }
+
+    const columns = [
+      {
+        name: "firstname",
+        download: true
+      },
+      {
+        name: "lastname",
+        download: true
+      }
+    ];
+
+    describe("when given two rows", () => {
+      const dataSet = [
+        [ "anton", "abraham" ],
+        [ "berta", "buchel" ]
+      ].map(data => ({ data }));
+
+      const csv = assembleCSV(columns, dataSet, options);
+
+      it("renders a two-record csv", () => {
+        expect(csv).to.equal(
+          '"firstname";"lastname"\r\n' +
+          '"anton";"abraham"\r\n' +
+          '"berta";"buchel"'
+        );
+      })
+    });
+
+    describe("when given an empty dataset", () => {
+      const columns = [
+        {
+          name: "firstname",
+          download: true
+        },
+        {
+          name: "lastname",
+          download: true
+        }
+      ];
+
+      const dataSet = [];
+
+      const csv = assembleCSV(
+        columns,
+        dataSet,
+        options
+      );
+
+      it("returns an empty csv with header", () => {
+        expect(csv).to.equal('"firstname";"lastname"');
+      })
+    })
+  })
+})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 import { assembleCSV, getPageValue } from '../src/utils';
-import { expect, assert } from 'chai';
+import { assert } from 'chai';
 
 describe('utils.js', () => {
   describe('assembleCSV', () => {
@@ -27,7 +27,7 @@ describe('utils.js', () => {
       const csv = assembleCSV(columns, dataSet, options);
 
       it('renders a two-record csv', () => {
-        expect(csv).to.equal('"firstname";"lastname"\r\n' + '"anton";"abraham"\r\n' + '"berta";"buchel"');
+        assert.strictEqual(csv, '"firstname";"lastname"\r\n' + '"anton";"abraham"\r\n' + '"berta";"buchel"');
       });
     });
 
@@ -48,7 +48,7 @@ describe('utils.js', () => {
       const csv = assembleCSV(columns, dataSet, options);
 
       it('returns an empty csv with header', () => {
-        expect(csv).to.equal('"firstname";"lastname"');
+        assert.strictEqual(csv, '"firstname";"lastname"');
       });
     });
 
@@ -64,7 +64,7 @@ describe('utils.js', () => {
       });
 
       it("returns null", () => {
-        expect(csv).to.be.null;
+        assert.isNull(csv);
       })
     });
   });


### PR DESCRIPTION
When downloading an empty dataset as CSV, there is a crash because you cannot `.trim()` an array.

This PR adds a fix and a regression test.