### PR TITLE
Force consistency with table metadata between array and object data

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -480,7 +480,8 @@ class MUIDataTable extends React.Component {
 
         if (typeof column.customBodyRender === 'function') {
           const rowData = tableData[rowIndex].data;
-          tableMeta = this.getTableMeta(rowIndex, colIndex, rowData, column, data, this.state);
+          const dataForTableMeta = this.transformData(columns, props.data);
+          tableMeta = this.getTableMeta(rowIndex, colIndex, rowData, column, dataForTableMeta, this.state);
           const funcResult = column.customBodyRender(value, tableMeta);
 
           if (React.isValidElement(funcResult) && funcResult.props.value) {
@@ -779,7 +780,7 @@ class MUIDataTable extends React.Component {
 
   getDisplayData(columns, data, filterList, searchText, tableMeta) {
     let newRows = [];
-    const dataForTableMeta = tableMeta ? tableMeta.tableData : this.props.data;
+    const dataForTableMeta = tableMeta ? tableMeta.tableData : this.transformData(columns, this.props.data);
 
     for (let index = 0; index < data.length; index++) {
       const value = data[index].data;


### PR DESCRIPTION
Closes https://github.com/gregnb/mui-datatables/issues/928.

Sending in array of arrays data vs array of objects data into the table was resulting in different `tableData` in the `tableMeta` object. Now, either should result in data that matches passing in array of arrays `tableData`.

It's possible this will be cause breakage for people relying on the inconsistent behavior, so saving this for a major release, unless I can trace it back as a relatively new issue, at which point, it could be released with a minor release.