### PR TITLE
Fix spacing issue for mui v4

### DIFF
--- a/examples/Router/ExamplesGrid.js
+++ b/examples/Router/ExamplesGrid.js
@@ -44,7 +44,7 @@ function ExamplesGrid(props) {
     return <React.Fragment>
         <Typography variant="h5" align="center">Choose an Example</Typography>
         <Typography variant="subtitle2" align="center">({examplesSortedKeys.length}) Examples</Typography>
-        <Grid container className={classes.container} spacing={16}>
+        <Grid container className={classes.container} spacing={1}>
             {examplesSortedKeys.map((label, index) => (
                 <Grid key={index} item md={2}>
                     <Link className={classes.link} to={`/${label.replace(/\s+/g, '-').toLowerCase()}`}>


### PR DESCRIPTION
material ui v4 changes how spacing works for grids, and certain values are no longer accepted