### PR TITLE
Enhancement/custom head render as child

### DIFF
--- a/examples/customize-columns/index.js
+++ b/examples/customize-columns/index.js
@@ -15,7 +15,7 @@ class Example extends React.Component {
       {
         name: 'Language',
         options: {
-          customHeadContentRender: () => <TranslateIcon />,
+          customHeadLabelRender: () => <TranslateIcon />,
         },
       },
       {

--- a/examples/customize-columns/index.js
+++ b/examples/customize-columns/index.js
@@ -1,85 +1,88 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import MUIDataTable from "../../src/";
+import React from 'react';
+import MUIDataTable from '../../src/';
+import TranslateIcon from '@material-ui/icons/Translate';
 
 class Example extends React.Component {
-
   render() {
-
     const columns = [
       {
-        name: "Name",
+        name: 'Name',
         options: {
           filter: true,
           display: 'excluded',
-        }
-      },      
-      {
-        label: "Modified Title Label",
-        name: "Title",
-        options: {
-          filter: true,
-          sortDirection: 'asc'
-        }
+        },
       },
       {
-        name: "Location",
+        name: 'Language',
+        options: {
+          customHeadContentRender: () => <TranslateIcon />,
+        },
+      },
+      {
+        label: 'Modified Title Label',
+        name: 'Title',
+        options: {
+          filter: true,
+          sortDirection: 'asc',
+        },
+      },
+      {
+        name: 'Location',
         options: {
           filter: false,
           customHeadRender: (columnMeta, updateDirection) => (
-            <th key={2} onClick={() => updateDirection(2)} style={{ cursor: 'pointer' }}>
+            <th key={columnMeta.index} onClick={() => updateDirection(columnMeta.index)} style={{ cursor: 'pointer' }}>
               {columnMeta.name}
             </th>
-          )
-        }
+          ),
+        },
       },
       {
-        name: "Age",
+        name: 'Age',
         options: {
           filter: true,
-        }
+        },
       },
       {
-        name: "Salary",
+        name: 'Salary',
         options: {
           filter: true,
-          sort: false
-        }
-      }      
+          sort: false,
+        },
+      },
     ];
 
-
     const data = [
-      ["Gabby George", "Business Analyst", "Minneapolis", 30, "$100,000"],
-      ["Aiden Lloyd", "Business Consultant", "Dallas",  55, "$200,000"],
-      ["Jaden Collins", "Attorney", "Santa Ana", 27, "$500,000"],
-      ["Franky Rees", "Business Analyst", "St. Petersburg", 22, "$50,000"],
-      ["Aaren Rose", "Business Consultant", "Toledo", 28, "$75,000"],
-      ["Blake Duncan", "Business Management Analyst", "San Diego", 65, "$94,000"],
-      ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, "$210,000"],
-      ["Lane Wilson", "Commercial Specialist", "Omaha", 19, "$65,000"],
-      ["Robin Duncan", "Business Analyst", "Los Angeles", 20, "$77,000"],
-      ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, "$135,000"],
-      ["Harper White", "Attorney", "Pittsburgh", 52, "$420,000"],
-      ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, "$150,000"],
-      ["Frankie Long", "Industrial Analyst", "Austin", 31, "$170,000"],
-      ["Brynn Robbins", "Business Analyst", "Norfolk", 22, "$90,000"],
-      ["Justice Mann", "Business Consultant", "Chicago", 24, "$133,000"],
-      ["Addison Navarro", "Business Management Analyst", "New York", 50, "$295,000"],
-      ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, "$200,000"],
-      ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, "$400,000"],
-      ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, "$110,000"],
-      ["Danny Leon", "Computer Scientist", "Newark", 60, "$220,000"],
-      ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, "$180,000"],
-      ["Jesse Hall", "Business Analyst", "Baltimore", 44, "$99,000"],
-      ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, "$90,000"],
-      ["Terry Macdonald", "Commercial Specialist", "Miami", 39, "$140,000"],
-      ["Justice Mccarthy", "Attorney", "Tucson", 26, "$330,000"],
-      ["Silver Carey", "Computer Scientist", "Memphis", 47, "$250,000" ],
-      ["Franky Miles", "Industrial Analyst", "Buffalo", 49, "$190,000"],
-      ["Glen Nixon", "Corporate Counselor", "Arlington", 44, "$80,000"],
-      ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, "$45,000"],
-      ["Mason Ray", "Computer Scientist", "San Francisco", 39, "$142,000"]
+      ['Gabby George', 'En', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
+      ['Aiden Lloyd', 'En', 'Business Consultant', 'Dallas', 55, '$200,000'],
+      ['Jaden Collins', 'En', 'Attorney', 'Santa Ana', 27, '$500,000'],
+      ['Franky Rees', 'En', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
+      ['Aaren Rose', 'En', 'Business Consultant', 'Toledo', 28, '$75,000'],
+      ['Blake Duncan', 'En', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
+      ['Frankie Parry', 'En', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
+      ['Lane Wilson', 'En', 'Commercial Specialist', 'Omaha', 19, '$65,000'],
+      ['Robin Duncan', 'En', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
+      ['Mel Brooks', 'En', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
+      ['Harper White', 'En', 'Attorney', 'Pittsburgh', 52, '$420,000'],
+      ['Kris Humphrey', 'Fr', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
+      ['Frankie Long', 'Fr', 'Industrial Analyst', 'Austin', 31, '$170,000'],
+      ['Brynn Robbins', 'Ch', 'Business Analyst', 'Norfolk', 22, '$90,000'],
+      ['Justice Mann', 'Fr', 'Business Consultant', 'Chicago', 24, '$133,000'],
+      ['Addison Navarro', 'Ch', 'Business Management Analyst', 'New York', 50, '$295,000'],
+      ['Jesse Welch', 'Ch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
+      ['Eli Mejia', 'Ch', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
+      ['Gene Leblanc', 'Fr', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
+      ['Danny Leon', 'Ch', 'Computer Scientist', 'Newark', 60, '$220,000'],
+      ['Lane Lee', 'Fr', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
+      ['Jesse Hall', 'Ch', 'Business Analyst', 'Baltimore', 44, '$99,000'],
+      ['Danni Hudson', 'Fr', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
+      ['Terry Macdonald', 'Ch', 'Commercial Specialist', 'Miami', 39, '$140,000'],
+      ['Justice Mccarthy', 'Ch', 'Attorney', 'Tucson', 26, '$330,000'],
+      ['Silver Carey', 'Ch', 'Computer Scientist', 'Memphis', 47, '$250,000'],
+      ['Franky Miles', 'Ch', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
+      ['Glen Nixon', 'Ch', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
+      ['Gabby Strickland', 'Ch', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
+      ['Mason Ray', 'Ch', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
     ];
 
     const options = {
@@ -88,10 +91,7 @@ class Example extends React.Component {
       responsive: 'stacked',
     };
 
-    return (
-      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
-    );
-
+    return <MUIDataTable title={'ACME Employee list'} data={data} columns={columns} options={options} />;
   }
 }
 

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -121,6 +121,7 @@ class MUIDataTable extends React.Component {
               }),
             ]),
             filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
+            customHeadContentRender: PropTypes.func,
             customHeadRender: PropTypes.func,
             customBodyRender: PropTypes.func,
             customFilterListRender: PropTypes.func,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -121,7 +121,7 @@ class MUIDataTable extends React.Component {
               }),
             ]),
             filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
-            customHeadContentRender: PropTypes.func,
+            customHeadLabelRender: PropTypes.func,
             customHeadRender: PropTypes.func,
             customBodyRender: PropTypes.func,
             customFilterListRender: PropTypes.func,

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -70,7 +70,7 @@ class TableHead extends React.Component {
                   print={column.print}
                   options={options}
                   column={column}>
-                  {column.label}
+                  {column.customHeadContentRender ? column.customHeadContentRender() : column.label}
                 </TableHeadCell>
               )),
           )}

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -70,7 +70,7 @@ class TableHead extends React.Component {
                   print={column.print}
                   options={options}
                   column={column}>
-                  {column.customHeadContentRender ? column.customHeadContentRender() : column.label}
+                  {column.customHeadLabelRender ? column.customHeadLabelRender() : column.label}
                 </TableHeadCell>
               )),
           )}


### PR DESCRIPTION
This feature adding `customHeadLabelRender` property

That property can accept FC or any function whose will be used as children
content of `TableHeadCell` component.

For example, now you can provide any icon as header:
![Example](https://i.imgur.com/sX4DTHt.png)

Pros of this feature:
+ less code than using `customHeadRender`
+ more predictable and compatible in future than `customHeadRender`