### PR TITLE
Upgrade testing performance and simplify

### DIFF
--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -902,15 +902,16 @@ describe('<MUIDataTable />', function() {
   });
 
   it('should recalculate page when calling changeRowsPerPage method', () => {
-    const data = new Array(29).fill('').map(() => ['Joe James', 'Test Corp', 'Yonkers', 'NY']);
-    const mountWrapper = mount(shallow(<MUIDataTable columns={columns} data={data} />).get(0));
+    const mountWrapper = mount(shallow(<MUIDataTable columns={columns} data={data} options={{ rowsPerPage: 2 }} />).get(0));
     const instance = mountWrapper.instance();
 
-    instance.changePage(2);
-    instance.changeRowsPerPage(15);
-
-    const state = mountWrapper.state();
+    instance.changePage(1);
+    let state = mountWrapper.state();
     assert.equal(state.page, 1);
+
+    instance.changeRowsPerPage(4);
+    state = mountWrapper.state();
+    assert.equal(state.page, 0);
   });
 
   it('should update page position when calling changePage method', () => {


### PR DESCRIPTION
This test sometimes times out when the test suite is run due to the way it is building new array data. It turns out that we don't need a new data set for this test, as we can use smaller rows per page number to get the same result on the existing data set in the test suite.