### PR TITLE
Stop mutating column.options props and support immutable data object

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -409,7 +409,7 @@ class MUIDataTable extends React.Component {
       };
 
       if (typeof column === 'object') {
-        const options = { ...column.options }
+        const options = { ...column.options };
         if (options) {
           if (options.display !== undefined) {
             options.display = options.display.toString();
@@ -422,7 +422,7 @@ class MUIDataTable extends React.Component {
             options.sortDirection = 'none';
           }
 
-          if (column.options.sortDirection !== undefined && column.options.sortDirection !== 'none') {
+          if (options.sortDirection !== undefined && options.sortDirection !== 'none') {
             if (sortDirectionSet) {
               console.error('sortDirection is set for more than one column. Only the first column will be considered.');
               options.sortDirection = 'none';

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -409,22 +409,23 @@ class MUIDataTable extends React.Component {
       };
 
       if (typeof column === 'object') {
-        if (column.options) {
-          if (column.options.display !== undefined) {
-            column.options.display = column.options.display.toString();
+        const options = { ...column.options }
+        if (options) {
+          if (options.display !== undefined) {
+            options.display = options.display.toString();
           }
 
-          if (column.options.sortDirection === null) {
+          if (options.sortDirection === null) {
             console.error(
               'The "null" option for sortDirection is deprecated. sortDirection is an enum, use "asc" | "desc" | "none"',
             );
-            column.options.sortDirection = 'none';
+            options.sortDirection = 'none';
           }
 
           if (column.options.sortDirection !== undefined && column.options.sortDirection !== 'none') {
             if (sortDirectionSet) {
               console.error('sortDirection is set for more than one column. Only the first column will be considered.');
-              column.options.sortDirection = 'none';
+              options.sortDirection = 'none';
             } else {
               sortDirectionSet = true;
             }
@@ -435,7 +436,7 @@ class MUIDataTable extends React.Component {
           name: column.name,
           label: column.label ? column.label : column.name,
           ...columnOptions,
-          ...(column.options ? column.options : {}),
+          ...options,
         };
       } else {
         columnOptions = { ...columnOptions, name: column, label: column };


### PR DESCRIPTION
I notice that the `MUIDataTable` is mutating the props.columns.options value and it causes error when passing an immutable object to it. 

Example, I'm using `immer` to update state and it produces immutable data object (using deep-freeze under the hood).

I think it is better to not mutate the props values inside the component.

**Change**
- Replace code that mutate `props.columns.options` by spreading `column.options` into new options before mutating

**Example**
https://codesandbox.io/s/dazzling-dijkstra-kmuf2
