### PR TITLE
add test case to verify reset type

### DIFF
--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -760,6 +760,21 @@ describe('<MUIDataTable />', function() {
     assert.strictEqual(changedColumn, null);
   });
 
+  it('should have the proper type in onFilterChange when calling resetFilters method', () => {
+    let type;
+    const options = {
+      onFilterChange: (changedColumn, filterList, changeType) => (type = changeType)
+    };
+
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} options={options} />);
+    const table = shallowWrapper.dive();
+    const instance = table.instance();
+
+    instance.resetFilters();
+    table.update();
+    assert.strictEqual(type, 'reset');
+  });
+
   it('should properly set searchText when calling searchTextUpdate method', () => {
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />);
     const table = shallowWrapper.dive();


### PR DESCRIPTION
A recent change #913 makes it's possible to identify a filterChange event by 'type === reset', which saved my day.
Here is a test case to ensure this feature exists forever.