### PR TITLE
Update overrides README for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,6 @@ class BodyCellExample extends React.Component {
 If you are using TypeScript, you will need to add this as well:
 
 ```ts
-import { Palette } from '@material-ui/core/styles/createPalette';
-
 declare module '@material-ui/core/styles/overrides' {
   interface ComponentNameToClassKey {
     // The following line is required, because in the example above, we are using MUIDataTableBodyCell overrides.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,34 @@ class BodyCellExample extends React.Component {
 
   }
 }
+```
 
+If you are using TypeScript, you will need to add this as well:
+
+```ts
+import { Palette } from '@material-ui/core/styles/createPalette';
+
+declare module '@material-ui/core/styles/overrides' {
+  interface ComponentNameToClassKey {
+    // The following line is required, because in the example above, we are using MUIDataTableBodyCell overrides.
+    MUIDataTableBodyCell: any;
+    // The rest below are optional. This is just to elaborate which overrides are available.
+    MUIDataTableBody: any;
+    MUIDataTableBodyRow: any;
+    MUIDataTableFilter: any;
+    MUIDataTableFilterList: any;
+    MUIDataTableHead: any;
+    MUIDataTableHeadCell: any;
+    MUIDataTableHeadRow: any;
+    MUIDataTablePagination: any;
+    MUIDataTableResize: any;
+    MUIDataTableSearch: any;
+    MUIDataTableSelectCell: any;
+    MUIDataTableToolbar: any;
+    MUIDataTableToolbarSelect: any;
+    MUIDataTableViewCol: any;
+  }
+}
 ```
 
 ## Remote Data


### PR DESCRIPTION
Hi! Thanks for this great library. I've been using it for quite some time now, and recently I have the need to customize the style (in this case, overriding). But, turned out, my IDE yelled at me that there was no overrides such as `MUIDatatable*`.

When I first time encountered this error, I had absolutely 0 idea on how to fix this (there is no issue around this I believe). Luckily, I already knew how to extend Material UI's interfaces with `declare module` syntax. So, I just needed to find which module in Material UI that contains the overrides typings and re-declared it in my own project.

I hope this little PR can help other people to override the styles of this library properly in TypeScript.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>