### PR TITLE
Updated table to make state persistent between renders

### DIFF
--- a/examples/data-as-objects/index.js
+++ b/examples/data-as-objects/index.js
@@ -4,6 +4,22 @@ import MUIDataTable from "../../src/";
 
 class Example extends React.Component {
 
+  state = {
+    counter: 0,
+    data: [
+      { name: "Gabby George", title: "Business Analyst", location: "Minneapolis", age: 30, salary: "$100,000", phone: { home: '867-5309', cell: '123-4567' } },
+      { name: "Aiden Lloyd", title: "Business Consultant", location: "Dallas",  age: 55, salary: "$200,000", phone: { home: '867-5310', cell: '123-4568' } },
+      { name: "Jaden Collins", title: "Attorney", location: "Santa Ana", age: 27, salary: "$500,000", phone: { home: '867-5311', cell: '123-4569' } },
+      { name: "Franky Rees", title: "Business Analyst", location: "St. Petersburg", age: 22, salary: "$50,000", phone: { home: '867-5312', cell: '123-4569' } }
+    ]
+  }
+
+  rerender = () => {
+    this.setState((prevState, props) => ({
+      counter: prevState.counter + 1
+    })); 
+  }
+
   render() {
 
     const columns = [
@@ -14,7 +30,7 @@ class Example extends React.Component {
           filter: true,
           display: 'excluded',
         }
-      },      
+      },      
       {
         name: "title",
         label: "Modified Title Label",
@@ -22,7 +38,7 @@ class Example extends React.Component {
           filter: true,
         }
       },
-      {        
+      {        
         name: "location",
         label: "Location",
         options: {
@@ -58,14 +74,6 @@ class Example extends React.Component {
       }
     ];
 
-
-    const data = [
-      { name: "Gabby George", title: "Business Analyst", location: "Minneapolis", age: 30, salary: "$100,000", phone: { home: '867-5309', cell: '123-4567' } },
-      { name: "Aiden Lloyd", title: "Business Consultant", location: "Dallas",  age: 55, salary: "$200,000", phone: { home: '867-5310', cell: '123-4568' } },
-      { name: "Jaden Collins", title: "Attorney", location: "Santa Ana", age: 27, salary: "$500,000", phone: { home: '867-5311', cell: '123-4569' } },
-      { name: "Franky Rees", title: "Business Analyst", location: "St. Petersburg", age: 22, salary: "$50,000", phone: { home: '867-5312', cell: '123-4569' } }
-    ];
-
     const options = {
       filter: true,
       filterType: 'dropdown',
@@ -73,7 +81,10 @@ class Example extends React.Component {
     };
 
     return (
-      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+      <React.Fragment>
+        <button onClick={this.rerender}>Re-render - {this.state.counter}</button>
+        <MUIDataTable title={"ACME Employee list"} data={this.state.data} columns={columns} options={options} />
+      </React.Fragment>
     );
 
   }

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -4,18 +4,26 @@ import MUIDataTable from "../../src/";
 
 class Example extends React.Component {
 
+  state = {
+    counter: 0,
+    data: [
+        ["Gabby George", "Business Analyst", "Minneapolis"],
+        ["Aiden Lloyd", "Business Consultant", "Dallas"],
+        ["Jaden Collins", "Attorney", "Santa Ana"],
+        ["Franky Rees", "Business Analyst", "St. Petersburg"],
+        ["Aaren Rose", null, "Toledo"]
+      ]
+  }
+
+  rerender = () => {
+    this.setState((prevState, props) => ({
+      counter: prevState.counter + 1
+    })); 
+  }
+
   render() {
 
     const columns = ["Name", "Title", "Location"];
-
-    const data = [
-      ["Gabby George", "Business Analyst", "Minneapolis"],
-      ["Aiden Lloyd", "Business Consultant", "Dallas"],
-      ["Jaden Collins", "Attorney", "Santa Ana"],
-      ["Franky Rees", "Business Analyst", "St. Petersburg"],
-      ["Aaren Rose", null, "Toledo"]
-    ];
-
 
     const options = {
       filter: true,
@@ -24,7 +32,10 @@ class Example extends React.Component {
     };
 
     return (
-      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+      <React.Fragment>
+        <button onClick={this.rerender}>Re-render - {this.state.counter}</button>
+        <MUIDataTable title={"ACME Employee list"} data={this.state.data} columns={columns} options={options} />
+      </React.Fragment>
     );
 
   }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -257,9 +257,15 @@ class MUIDataTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns) {
+    if (this.props.data !== prevProps.data || this.props.columns !== prevProps.columns || this.props.options !== prevProps.options) {
       this.updateOptions(this.options, this.props);
-      this.setTableData(this.props, TABLE_LOAD.INITIAL, () => {
+
+      var didDataUpdate = this.props.data !== prevProps.data;
+      if ( this.props.data && prevProps.data ) {
+        didDataUpdate = didDataUpdate && (this.props.data.length === prevProps.data.length);
+      }
+
+      this.setTableData(this.props, TABLE_LOAD.INITIAL, didDataUpdate, () => {
         this.setTableAction('propsUpdate');
       });
     }
@@ -291,7 +297,7 @@ class MUIDataTable extends React.Component {
   initializeTable(props) {
     this.mergeDefaultOptions(props);
     this.setTableOptions();
-    this.setTableData(props, TABLE_LOAD.INITIAL, () => {
+    this.setTableData(props, TABLE_LOAD.INITIAL, true, () => {
       this.setTableInit('tableInitialized');
     });
   }
@@ -361,8 +367,8 @@ class MUIDataTable extends React.Component {
   };
 
   /*
-   * React currently does not support deep merge for defaultProps. Objects are overwritten
-   */
+   * React currently does not support deep merge for defaultProps. Objects are overwritten
+   */
   mergeDefaultOptions(props) {
     const defaultOptions = this.getDefaultOptions();
 
@@ -417,10 +423,10 @@ class MUIDataTable extends React.Component {
   getTableContentRef = () => this.tableContent.current;
 
   /*
-   *  Build the source table data
-   */
+   *  Build the source table data
+   */
 
-  buildColumns = newColumns => {
+  buildColumns = (newColumns, prevColumns) => {
     let columnData = [];
     let filterData = [];
     let filterList = [];
@@ -439,8 +445,9 @@ class MUIDataTable extends React.Component {
         sortDirection: 'none',
       };
 
+      const options = { ...column.options };
+
       if (typeof column === 'object') {
-        const options = { ...column.options };
         if (options) {
           if (options.display !== undefined) {
             options.display = options.display.toString();
@@ -463,6 +470,24 @@ class MUIDataTable extends React.Component {
           }
         }
 
+        // remember stored version of display and sortDirection if not overwritten
+        if (
+          typeof options.display === 'undefined' &&
+          prevColumns[colIndex] && 
+          prevColumns[colIndex].name === column.name && 
+          prevColumns[colIndex].display
+        ) {
+            options.display = prevColumns[colIndex].display;
+        }
+        if (
+          typeof options.sortDirection === 'undefined' &&
+          prevColumns[colIndex] && 
+          prevColumns[colIndex].name === column.name && 
+          prevColumns[colIndex].sortDirection
+        ) {
+            options.sortDirection = prevColumns[colIndex].sortDirection;
+        }
+
         columnOptions = {
           name: column.name,
           label: column.label ? column.label : column.name,
@@ -470,7 +495,22 @@ class MUIDataTable extends React.Component {
           ...options,
         };
       } else {
-        columnOptions = { ...columnOptions, name: column, label: column };
+
+        // remember stored version of display and sortDirection if not overwritten
+        if (
+          prevColumns[colIndex] && 
+          prevColumns[colIndex].display
+        ) {
+            options.display = prevColumns[colIndex].display;
+        }
+        if (
+          prevColumns[colIndex] && 
+          prevColumns[colIndex].sortDirection
+        ) {
+            options.sortDirection = prevColumns[colIndex].sortDirection;
+        }
+
+        columnOptions = { ...columnOptions, ...options, name: column, label: column };
       }
 
       columnData.push(columnOptions);
@@ -509,15 +549,19 @@ class MUIDataTable extends React.Component {
     return transformedData;
   };
 
-  setTableData(props, status, callback = () => {}) {
+  setTableData(props, status, dataUpdated, callback = () => {}) {
     let tableData = [];
-    let { columns, filterData, filterList } = this.buildColumns(props.columns);
+    let { columns, filterData, filterList } = this.buildColumns(props.columns, this.state.columns);
     let sortIndex = null;
     let sortDirection = 'none';
     let tableMeta;
 
     const data = status === TABLE_LOAD.INITIAL ? this.transformData(columns, props.data) : props.data;
-    const searchText = status === TABLE_LOAD.INITIAL ? this.options.searchText : null;
+    let searchText = status === TABLE_LOAD.INITIAL ? this.options.searchText : null;
+
+    if (typeof this.options.searchText === 'undefined' && typeof this.state.searchText !== 'undefined') {
+      searchText = this.state.searchText;
+    }
 
     columns.forEach((column, colIndex) => {
       for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
@@ -566,6 +610,8 @@ class MUIDataTable extends React.Component {
 
       if (column.filterList) {
         filterList[colIndex] = cloneDeep(column.filterList);
+      } else if ( this.state.filterList && this.state.filterList[colIndex] && this.state.filterList[colIndex].length > 0) {
+        filterList[colIndex] = cloneDeep(this.state.filterList[colIndex]);
       }
 
       if (this.options.sortFilterList) {
@@ -605,14 +651,14 @@ class MUIDataTable extends React.Component {
           selectedRowsData.data.push({ index: rowPos, dataIndex: row });
           selectedRowsData.lookup[row] = true;
         });
-      }
 
       // Single row selection customization
-      if (
+      } else if (
         this.options.rowsSelected &&
         this.options.rowsSelected.length === 1 &&
         this.options.selectableRows === 'single'
       ) {
+
         let rowPos = this.options.rowsSelected[0];
 
         for (let cIndex = 0; cIndex < this.state.displayData.length; cIndex++) {
@@ -632,6 +678,10 @@ class MUIDataTable extends React.Component {
         console.error(
           'Multiple values provided for selectableRows, but selectableRows set to "single". Either supply only a single value or use "multiple".',
         );
+      } else if (typeof this.options.rowsSelected === 'undefined' && dataUpdated === false) {
+        if (this.state.selectedRows) {
+          selectedRowsData = Object.assign({}, this.state.selectedRows);
+        }
       }
 
       if (this.options.rowsExpanded && this.options.rowsExpanded.length && this.options.expandableRows) {
@@ -648,6 +698,8 @@ class MUIDataTable extends React.Component {
           expandedRowsData.data.push({ index: rowPos, dataIndex: row });
           expandedRowsData.lookup[row] = true;
         });
+      } else if (typeof this.options.rowsExpanded === 'undefined' && dataUpdated === false && this.state.expandedRows) {
+        expandedRowsData = Object.assign({}, this.state.expandedRows);
       }
     }
 
@@ -668,15 +720,14 @@ class MUIDataTable extends React.Component {
         count: this.options.count,
         data: tableData,
         displayData: this.getDisplayData(columns, tableData, filterList, searchText, tableMeta),
-        previousSelectedRow: null,
       },
       callback,
     );
   }
 
   /*
-   *  Build the table data used to display to the user (ie: after filter/search applied)
-   */
+   *  Build the table data used to display to the user (ie: after filter/search applied)
+   */
   computeDisplayRow(columns, row, rowIndex, filterList, searchText, dataForTableMeta) {
     let isFiltered = false;
     let isSearchFound = false;
@@ -1090,6 +1141,7 @@ class MUIDataTable extends React.Component {
         },
       },
       TABLE_LOAD.UPDATE,
+      true,
       () => {
         this.setTableAction('rowDelete');
       },
@@ -1161,7 +1213,7 @@ class MUIDataTable extends React.Component {
             return arr;
           }, []);
 
-          let newRows = [...prevState.selectedRows, ...selectedRows];
+          let newRows = [...selectedRows];
           let selectedMap = buildMap(newRows);
 
           // if the select toolbar is disabled, the rules are a little different


### PR DESCRIPTION
This PR updates the table so that it maintains it's state between re-renders for properties that are not overwritten by the user (https://github.com/gregnb/mui-datatables/issues/807, https://github.com/gregnb/mui-datatables/issues/947, https://github.com/gregnb/mui-datatables/issues/1057). I've updated the "Simple" and "Data as Objects" examples with a "re-render" button that shows that search text, filters, selections, sorting, etc etc, are not lost when the table re-renders.

Some notes:

* Selected Rows and Expanded Rows reset if the data changes. This is why I've put the data on the component's state for the 2 examples I updated. In my own use, I found that if the table's data changed, it made no sense for the selections and expansions to stay in place.
* The Trash Can in the toolbar doesn't effect the external state data in those two examples, so any deleted data is returned to the table on re-render. This makes sense because the user is inputing non-modified data to the component, so the table should use the non-modified data rather than internal data that is modified.
* I'm not sure of a good way to test this. I've copied over my edits from the mui-dt repo I mentioned in the other thread, and I'd been using the changes over there in my app without issue.