### PR TITLE
Added search and "back to index" button to Example Grid

### DIFF
--- a/examples/Router/ExamplesGrid.js
+++ b/examples/Router/ExamplesGrid.js
@@ -3,6 +3,7 @@ import {Card, CardContent, Grid, Typography} from "@material-ui/core";
 import React from "react";
 import examples from "../examples";
 import {withStyles} from "@material-ui/core/styles/index";
+import TextField from '@material-ui/core/TextField';
 
 const styles = {
     container: {
@@ -30,8 +31,20 @@ const styles = {
     }
 };
 
-function ExamplesGrid(props) {
-    const {classes} = props;
+class ExamplesGrid extends React.Component {
+
+  state = {
+    searchVal: ''
+  }
+
+  setSearchVal = (val) => {
+    this.setState({
+      searchVal: val
+    });
+  }
+
+  render() {
+    const {classes} = this.props;
 
     // Sort Examples alphabetically
     const examplesSorted = {};
@@ -39,25 +52,37 @@ function ExamplesGrid(props) {
         examplesSorted[key] = examples[key];
     });
 
-    const examplesSortedKeys = Object.keys(examplesSorted);
+    const examplesSortedKeys = Object.keys(examplesSorted).filter((item) => {
+      if (this.state.searchVal === '') return true;
+      console.dir(item);
+      return item.toLowerCase().indexOf( this.state.searchVal.toLowerCase() ) !== -1 ? true : false;
+    });
 
-    return <React.Fragment>
+    return (
+      <React.Fragment>
         <Typography variant="h5" align="center">Choose an Example</Typography>
         <Typography variant="subtitle2" align="center">({examplesSortedKeys.length}) Examples</Typography>
+
+        <Typography variant="subtitle2" align="center" style={{margin:'10px'}}>
+          <TextField placeholder="Search Examples" value={this.state.searchVal} onChange={(e) => this.setSearchVal(e.target.value)} />
+        </Typography>
+
         <Grid container className={classes.container} spacing={16}>
-            {examplesSortedKeys.map((label, index) => (
-                <Grid key={index} item md={2}>
-                    <Link className={classes.link} to={`/${label.replace(/\s+/g, '-').toLowerCase()}`}>
-                        <Card className={classes.card}>
-                            <CardContent className={classes.cardContent}>
-                                <Typography variant="subtitle1" className={classes.label} align="center">{label}</Typography>
-                            </CardContent>
-                        </Card>
-                    </Link>
-                </Grid>
-            ))}
+          {examplesSortedKeys.map((label, index) => (
+            <Grid key={index} item md={2}>
+              <Link className={classes.link} to={`/${label.replace(/\s+/g, '-').toLowerCase()}`}>
+                <Card className={classes.card}>
+                  <CardContent className={classes.cardContent}>
+                    <Typography variant="subtitle1" className={classes.label} align="center">{label}</Typography>
+                  </CardContent>
+                </Card>
+              </Link>
+            </Grid>
+          ))}
         </Grid>
-    </React.Fragment>;
+      </React.Fragment>
+    );
+  }
 }
 
 export default withStyles(styles)(ExamplesGrid);

--- a/examples/Router/index.js
+++ b/examples/Router/index.js
@@ -4,6 +4,8 @@ import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 import {withStyles} from "@material-ui/core/styles/index";
 import ExamplesGrid from "./ExamplesGrid";
 import examples from "../examples";
+import Button from "@material-ui/core/Button";
+import {withRouter} from 'react-router-dom';
 
 const styles = {
     root: {
@@ -15,22 +17,45 @@ const styles = {
     },
 };
 
-function Examples(props) {
-    const {classes} = props;
-    return <main className={classes.root}>
-        <div className={classes.contentWrapper}>
-            <Router hashType="noslash">
+class Examples extends React.Component {
+
+    returnHome = () => {
+        this.props.history.push('/');
+    };
+
+    render() {
+        const {classes} = this.props;
+
+        var returnHomeStyle = {padding:'0px', margin:'20px 0 20px 0'};
+
+        return <main className={classes.root}>
+            <div className={classes.contentWrapper}>
                 <Switch>
                     <Route path="/" exact render={() => <ExamplesGrid examples={examples}/>}/>
                     {Object.keys(examples).map((label, index) => (
                         <Route key={index} path={`/${label.replace(/\s+/g, '-').toLowerCase()}`} exact component={examples[label]}/>
                     ))}
                 </Switch>
-            </Router>
-        </div>
-    </main>;
+                <div>
+                    {this.props.location.pathname !== '/' && (
+                      <div style={returnHomeStyle}>
+                        <Button color="primary" onClick={this.returnHome}>Back to Example Index</Button>
+                      </div>
+                    )}
+                </div>
+            </div>
+        </main>;
+    }
 }
 
-const StyledExamples = withStyles(styles)(Examples);
+const StyledExamples = withRouter( withStyles(styles)(Examples) );
 
-ReactDOM.render(<StyledExamples/>, document.getElementById('app-root'));
+function App() {
+  return (
+    <Router hashType="noslash">
+      <StyledExamples />
+    </Router>
+  );
+}
+
+ReactDOM.render(<App/>, document.getElementById('app-root'));

--- a/examples/serverside-sorting/index.js
+++ b/examples/serverside-sorting/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import MUIDataTable from '../../src';
 import { CircularProgress, Typography } from '@material-ui/core';
-import Cities from './Cities';
+import Cities from './cities';
 
 class Example extends React.Component {
   state = {


### PR DESCRIPTION
This PR adds a search box to the main example grid and adds a "return to index" button to each example. This makes navigating the examples easier. I also fixed a typo in one of the examples which was causing the repo not to work with codesandbox.

Quick view: https://codesandbox.io/s/github/patorjk/mui-datatables/tree/examplegrid_updates