### PR TITLE
Debounced Search Plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,15 @@ function(value: any, tableMeta: {
 }, updateValue: function)
 ```
 
+## Plug-ins
+
+The table lends itself to plug-ins in many areas, especially in the customRender functions. Many use cases for these render functions are common, so a set of plug-ins are available that you can use.
+
+#### Available Plug-ins:
+|Name|Type|Default|Description
+|:--:|:-----|:--|:-----|
+|**`debounceSearchRender`**|function||Function that returns a function for the customSearchRender method. This plug-in allows you to create a debounced search which can be useful for server-side tables and tables with large data sets. `function(debounceWait) => function` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/large-data-set/index.js)
+
 ## Customize Styling
 
 Using Material-UI theme overrides will allow you to customize styling to your liking. First, determine which component you would want to target and then lookup the override classname. Let's start with a simple example where we will change the background color of a body cell to be red:

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -30,6 +30,7 @@ import Simple from './simple';
 import SimpleNoToolbar from './simple-no-toolbar';
 import TextLocalization from './text-localization';
 import Themes from './themes';
+import LargeDataSet from './large-data-set';
 
 /**
  * Here you can add any extra examples with the Card label as the key, and the component to render as the value
@@ -55,6 +56,7 @@ export default {
   'Expandable Rows': ExpandableRows,
   'Fixed Header': FixedHeader,
   'Hide Columns Print': HideColumnsPrint,
+  'Large Data Set': LargeDataSet,
   OnDownload: OnDownload,
   OnTableInit: OnTableInit,
   'Resizable Columns': ResizableColumns,

--- a/examples/large-data-set/index.js
+++ b/examples/large-data-set/index.js
@@ -1,0 +1,133 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import MUIDataTable from "../../src/";
+import { debounceSearchRender } from "../../src/";
+
+class Example extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    const rand = (size) => {
+      return Math.floor( Math.random() * size );
+    };
+
+    const firstNames = ['Adam', 'Jack', 'Edward', 'Donna', 'Sarah', 'Suzie', 'Sam', 'RJ', 'Henry', 'Ryan', 'Ricky', 'James'];
+    const lastNames  = ['Ronson', 'Johnson', 'Jackson', 'Campo', 'Edwards', 'Brown', 'Green', 'White', 'Simmons', 'Gates', 'Jobs'];
+    const titles = ['Owner', 'Unemployed', 'Burger Flipper', 'Coder', 'Business Analyst', 'Attorney', 'Consultant', 'Singer','Painter'];
+    const locations = ['New York', 'El Paso', 'DC', 'Dallas', 'Santa Ana','St. Petersburg', 'London','Paris'];
+    const salarys = ['$100,000', '$50,000', '$75,000', '$80,000'];
+    var data = [];
+    var name = '';
+
+    for (var ii = 0; ii < 5000; ii++) {
+      name = firstNames[ rand(firstNames.length)] + ' ' + lastNames[ rand(lastNames.length) ];
+      data.push({
+        name: name,
+        title: titles[ rand(titles.length)],
+        location: locations[ rand(locations.length) ],
+        salary: salarys[ rand(salarys.length )],
+        phone: '555-5555',
+        email: name.replace(/ /g, '_').toLowerCase() + '@example.com',
+      });
+    }
+
+    this.state = {
+      data: data
+    };
+    console.time('Render Time');
+  }
+
+  componentDidMount() {
+    console.timeEnd('Render Time');
+  }
+
+  render() {
+
+    const columns = [
+      {
+        name: "name",
+        label: "Name",
+        options: {
+          filter: true,
+          customBodyRender: (val) => {
+            return val;
+          }
+        }
+      },      
+      {
+        name: "title",
+        label: "Modified Title Label",
+        options: {
+          filter: true,
+          customBodyRender: (val) => {
+            return val;
+          }
+        }
+      },
+      {        
+        name: "location",
+        label: "Location",
+        options: {
+          filter: false,
+        }
+      },
+      {
+        name: "age",
+        Label: "Age",
+        options: {
+          filter: true,
+        }
+      },
+      {
+        name: "salary",
+        label: "Salary",
+        options: {
+          filter: true,
+          sort: false,
+          customBodyRender: (val) => {
+            return val;
+          }
+        }
+      },
+      {
+        name: "phone",
+        label: "Phone",
+        options: {
+          filter: true,
+          sort: false,
+          customBodyRender: (val) => {
+            return val;
+          }
+        }
+      },
+      {
+        name: "email",
+        label: "E-mail",
+        options: {
+          filter: true,
+          sort: false,
+          customBodyRender: (val) => {
+            return val;
+          }
+        }
+      }
+    ];
+
+    const options = {
+      rowsPerPage: 500,
+      rowsPerPageOptions: [10, 100, 250, 500, 1000],
+      filter: true,
+      filterType: 'dropdown',
+      responsive: 'scrollMaxHeight',
+      customSearchRender: debounceSearchRender(500),
+    };
+
+    return (
+      <MUIDataTable title={"ACME Employee list"} data={this.state.data} columns={columns} options={options} />
+    );
+
+  }
+}
+
+export default Example;

--- a/src/index.js
+++ b/src/index.js
@@ -16,3 +16,7 @@ export { default as TableSelectCell } from './components/TableSelectCell';
 export { default as TableToolbar } from './components/TableToolbar';
 export { default as TableToolbarSelect } from './components/TableToolbarSelect';
 export { default as TableViewCol } from './components/TableViewCol';
+export { 
+  debounceSearchRender, 
+  DebounceTableSearch 
+} from './plug-ins/DebounceSearchRender';

--- a/src/plug-ins/DebounceSearchRender.js
+++ b/src/plug-ins/DebounceSearchRender.js
@@ -1,0 +1,114 @@
+import React, {useEffect} from 'react';
+import Grow from '@material-ui/core/Grow';
+import TextField from '@material-ui/core/TextField';
+import SearchIcon from '@material-ui/icons/Search';
+import IconButton from '@material-ui/core/IconButton';
+import ClearIcon from '@material-ui/icons/Clear';
+import { withStyles } from '@material-ui/core/styles';
+
+function debounce(func, wait, immediate) {
+  var timeout;
+  return function() {
+    var context = this, args = arguments;
+    var later = function() {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+};
+
+const defaultStyles = (theme) => ({
+  main: {
+    display: 'flex',
+    flex: '1 0 auto',
+  },
+  searchIcon: {
+    color: theme.palette.text.secondary,
+    marginTop: '10px',
+    marginRight: '8px',
+  },
+  searchText: {
+    flex: '0.8 0',
+  },
+  clearIcon: {
+    '&:hover': {
+      color: theme.palette.error.main,
+    },
+  },
+});
+
+class _DebounceTableSearch extends React.Component {
+
+  handleTextChangeWrapper = debouncedSearch => {
+    return function(event) {
+      debouncedSearch(event.target.value);
+    };
+  };
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.onKeyDown, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeyDown, false);
+  }
+
+  onKeyDown = event => {
+    if (event.keyCode === 27) {
+      this.props.onHide();
+    }
+  };
+
+  render() {
+    const { classes, options, onHide, searchText, debounceWait } = this.props;
+
+    const debouncedSearch = debounce((value) => {
+      this.props.onSearch(value);
+    }, debounceWait);
+
+    return (
+      <Grow appear in={true} timeout={300}>
+        <div className={classes.main}>
+          <SearchIcon className={classes.searchIcon} />
+          <TextField
+            className={classes.searchText}
+            autoFocus={true}
+            InputProps={{
+              'data-test-id': options.textLabels.toolbar.search,
+              'aria-label': options.textLabels.toolbar.search,
+            }}
+            defaultValue={searchText}
+            onChange={this.handleTextChangeWrapper(debouncedSearch)}
+            fullWidth={true}
+            inputRef={el => (this.searchField = el)}
+            placeholder={options.searchPlaceholder}
+          />
+          <IconButton className={classes.clearIcon} onClick={onHide}>
+            <ClearIcon />
+          </IconButton>
+        </div>
+      </Grow>
+    );
+  }
+}
+
+var DebounceTableSearch = withStyles(defaultStyles, { name: 'MUIDataTableSearch' })(_DebounceTableSearch);
+export { DebounceTableSearch };
+
+export function debounceSearchRender(debounceWait = 200) {
+  return (searchText, handleSearch, hideSearch, options) => {
+    return (
+      <DebounceTableSearch
+        searchText={searchText}
+        onSearch={handleSearch}
+        onHide={hideSearch}
+        options={options}
+        debounceWait={debounceWait}
+      />
+    );
+  };
+};


### PR DESCRIPTION
This PR introduces the idea of "plug-ins" to the table. The tables lends itself to plug-ins in many areas and many of the use cases are common. The addition of plug-ins like this will **not** increase the file size for people who don't use them (since webpack will only add them to a person's bundle if they explicitly import them).

This plug-in is for the common use-case of a debounced search. It's useful in two areas:

* Server-side tables that don't want to execute an ajax request right away.
* Client-side tables which have a large data set.

I've included an example for how to use the plug-in in a new example called "Large Data Set". This example also shows the render time for the table and will be useful in another PR I submit later for performance improvements (this will need to be merged in first so you can see before/after render times).

Other future ideas for plug-ins:

* Editable cells or rows, similar to Material-Table.
* Different onDownload/export renders (ex: ones that use the BOM, do different pre-processing of data, etc etc)
* Different types of footers - specifically some footers have a "jump to page" feature, which is really handy. Though that may make more sense as a general option rather than alternative footer.

Additionally, keeping this kind of stuff (especially editable cells) as plug-ins will make the table lighter weight and make it preform better while being able to support advanced features.