### PR TITLE
Added expandable row header (expandableRowsHeader option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The component accepts the following props:
 |**`isRowExpandable`**|function||Enable/disable expansion or collapse on certain expandable rows with custom function. Will be considered true if not provided. `function(dataIndex: number, expandedRows: object(lookup: {dataIndex: number}, data: arrayOfObjects: {index: number, dataIndex: number})) => boolean`.
 |**`selectableRowsHeader`**|boolean|true|Show/hide the select all/deselect all checkbox header for selectable rows
 |**`expandableRows`**|boolean|false|Enable/disable expandable rows
+|**`expandableRowsHeader`**|boolean|true|Show/hide the expand all/collapse all row header for expandable rows.
 |**`expandableRowsOnClick`**|boolean|false|Enable/disable expand trigger when row is clicked. When False, only expand icon will trigger this action.
 |**`renderExpandableRow`**|function||Render expandable row. `function(rowData, rowMeta) => React Component`
 |**`resizableColumns`**|boolean|false|Enable/disable resizable columns

--- a/examples/expandable-rows/index.js
+++ b/examples/expandable-rows/index.js
@@ -82,6 +82,7 @@ class Example extends React.Component {
       filterType: 'dropdown',
       responsive: 'scrollMaxHeight',
       expandableRows: true,
+      expandableRowsHeader: true,
       expandableRowsOnClick: true,
       isRowExpandable: (dataIndex, expandedRows) => {
         // Prevent expand/collapse of any row if there are 4 rows expanded already (but allow those already expanded to be collapsed)

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -30,7 +30,7 @@ class TableHead extends React.Component {
   };
 
   render() {
-    const { classes, columns, count, options, data, setCellRef, selectedRows } = this.props;
+    const { classes, columns, count, options, data, setCellRef, selectedRows, expandedRows } = this.props;
 
     const numSelected = (selectedRows && selectedRows.data.length) || 0;
     let isIndeterminate = numSelected > 0 && numSelected < count;
@@ -65,11 +65,14 @@ class TableHead extends React.Component {
             indeterminate={isIndeterminate}
             checked={isChecked}
             isHeaderCell={true}
+            expandedRows={expandedRows}
+            expandableRowsHeader={options.expandableRowsHeader}
             expandableOn={options.expandableRows}
             selectableOn={options.selectableRows}
             fixedHeader={options.fixedHeader}
             fixedHeaderOptions={options.fixedHeaderOptions}
             selectableRowsHeader={options.selectableRowsHeader}
+            onExpand={this.props.toggleAllExpandableRows}
             isRowSelectable={true}
           />
           {columns.map(

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -6,6 +6,7 @@ import TableCell from '@material-ui/core/TableCell';
 import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+import Remove from '@material-ui/icons/Remove';
 
 const defaultSelectCellStyles = theme => ({
   root: {},
@@ -90,6 +91,9 @@ class TableSelectCell extends React.Component {
       isRowSelectable,
       selectableRowsHeader,
       hideExpandButton,
+      expandableRowsHeader,
+      expandedRows,
+      areAllRowsExpanded = () => (false),
       ...otherProps
     } = this.props;
     let fixedHeaderClasses;
@@ -117,8 +121,12 @@ class TableSelectCell extends React.Component {
 
     const iconClass = classNames({
       [classes.icon]: true,
-      [classes.hide]: isHeaderCell,
-      [classes.expanded]: isRowExpanded,
+      [classes.hide]: isHeaderCell && !expandableRowsHeader,
+      [classes.expanded]: isRowExpanded || (isHeaderCell && areAllRowsExpanded()),
+    });
+    const iconIndeterminateClass = classNames({
+      [classes.icon]: true,
+      [classes.hide]: isHeaderCell && !expandableRowsHeader,
     });
 
     const renderCheckBox = () => {
@@ -144,9 +152,17 @@ class TableSelectCell extends React.Component {
       <TableCell className={cellClass} padding="checkbox">
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {expandableOn && (
-            <IconButton onClick={onExpand} disabled={isHeaderCell} className={buttonClass}>
-              <KeyboardArrowRight id="expandable-button" className={iconClass} />
-            </IconButton>
+            <React.Fragment>
+              {(isHeaderCell && !areAllRowsExpanded() && expandedRows && expandedRows.data.length > 0 ) ?
+                <IconButton onClick={onExpand} style={{padding:0}} disabled={expandableRowsHeader === false}>
+                  <Remove id="expandable-button" className={iconIndeterminateClass} />
+                </IconButton>
+                :
+                <IconButton onClick={onExpand} style={{padding:0}} disabled={expandableRowsHeader === false}>
+                  <KeyboardArrowRight id="expandable-button" className={iconClass} />
+                </IconButton>
+              }
+            </React.Fragment>
           )}
           {selectableOn !== 'none' && renderCheckBox()}
         </div>


### PR DESCRIPTION
Resolves https://github.com/gregnb/mui-datatables/issues/740

This PR adds the option expandableRowsHeader which defaults to true. Users will now be able to toggle all rows open or closed by clicking a button in the header. I've updated the Expandable Rows example to add the option in. You can toggle it to false to see the behavior of the table when the header isn't present.