### PR TITLE
Added confirmFilters option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 MUI-Datatables is a data tables component built on [Material-UI](https://www.material-ui.com).  It comes with features like filtering, resizable + view/hide columns, search, export to CSV download, printing, selectable rows, expandable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are three responsive modes "stacked", "scrollMaxHeight", and "scrollFullHeight" for mobile/tablet devices.
 
 <div align="center">
-	<img src="https://user-images.githubusercontent.com/19170080/38026128-eac9d506-3258-11e8-92a7-b0d06e5faa82.gif" />
+  <img src="https://user-images.githubusercontent.com/19170080/38026128-eac9d506-3258-11e8-92a7-b0d06e5faa82.gif" />
 </div>
 
 ## Install
@@ -136,6 +136,7 @@ The component accepts the following props:
 |**`count`**|number||User provided override for total number of rows
 |**`serverSide`**|boolean|false|Enable remote data source
 |**`serverSideFilterList`**|array|[]|Sets the filter list display when using serverSide: true
+|**`confirmFilters`**|boolean|false|Works in conjunction with the customFilterDialogFooter option and makes it so filters have to be confirmed before being applied to the table. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters---confirmfilters/index.js)
 |**`rowsSelected`**|array||User provided selected rows
 |**`rowsExpanded`**|array||User provided expanded rows
 |**`filterType`**|string||Choice of filtering view. `enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom')`
@@ -158,7 +159,7 @@ The component accepts the following props:
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`customSearchRender `**|function||Render a custom table search. `customSearchRender(searchText: string, handleSearch, hideSearch, options) => React Component`
-|**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(filterList: array) => React Component`
+|**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(curentFilterList: array, applyFilters: function) => React Component`
 |**`elevation`**|number|4|Shadow depth applied to Paper component
 |**`caseSensitive `**|boolean|false|Enable/disable case sensitivity for search
 |**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage)
@@ -174,7 +175,7 @@ The component accepts the following props:
 |**`searchOpen`**|boolean|false|Initially displays search bar  
 |**`searchText`**|string||Initial search text
 |**`searchPlaceholder`**|string||Search text placeholder. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
-|**`print`**|boolean|true|Show/hide print	 icon from toolbar
+|**`print`**|boolean|true|Show/hide print  icon from toolbar
 |**`download`**|boolean|true|Show/hide download icon from toolbar
 |**`downloadOptions`**|object|`{filename: 'tableDownload.csv', separator: ','}`|Options to change the output of the CSV file: `filename`: string, `separator`: string, `filterOptions`: object(`useDisplayedColumnsOnly`: boolean, `useDisplayedRowsOnly`: boolean)
 |**`onDownload`**|function||A callback function that triggers when the user downloads the CSV file. In the callback, you can control what is written to the CSV file. `function(buildHead: (columns) => string, buildBody: (data) => string, columns, data) => string`. Return `false` to cancel download of file.

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -23,6 +23,7 @@ import OnTableInit from './on-table-init';
 import ResizableColumns from './resizable-columns';
 import SelectableRows from './selectable-rows';
 import ServerSideFilters from './serverside-filters';
+import ServerSideFiltersConfirmFilters from './serverside-filters-confirmFilters';
 import ServerSideOptions from './serverside-options';
 import ServerSidePagination from './serverside-pagination';
 import ServerSideSorting from './serverside-sorting';
@@ -60,6 +61,7 @@ export default {
   'Resizable Columns': ResizableColumns,
   'Selectable Rows': SelectableRows,
   'ServerSide Filters': ServerSideFilters,
+  'ServerSide Filters - confirmFilters': ServerSideFiltersConfirmFilters,
   'ServerSide Options': ServerSideOptions,
   'ServerSide Pagination': ServerSidePagination,
   'ServerSide Sorting': ServerSideSorting,

--- a/examples/serverside-filters-confirmFilters/index.js
+++ b/examples/serverside-filters-confirmFilters/index.js
@@ -1,0 +1,207 @@
+import { Button, CircularProgress } from '@material-ui/core';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MUIDataTable from '../../src';
+
+class Example extends React.Component {
+  state = {
+    filters: [[], [], [], [], []],
+    isLoading: false,
+    data: [
+      ['Gabby George', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
+      ['Aiden Lloyd', 'Business Consultant', 'Dallas', 55, '$200,000'],
+      ['Jaden Collins', 'Attorney', 'Santa Ana', 27, '$500,000'],
+      ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
+      ['Aaren Rose', 'Business Consultant', 'Toledo', 28, '$75,000'],
+      ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
+      ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
+      ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
+      ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
+      ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
+      ['Harper White', 'Attorney', 'Pittsburgh', 52, '$420,000'],
+      ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
+      ['Frankie Long', 'Industrial Analyst', 'Austin', 31, '$170,000'],
+      ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, '$90,000'],
+      ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000'],
+      ['Addison Navarro', 'Business Management Analyst', 'New York', 50, '$295,000'],
+      ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
+      ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
+      ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
+      ['Danny Leon', 'Computer Scientist', 'Newark', 60, '$220,000'],
+      ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
+      ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, '$99,000'],
+      ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
+      ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, '$140,000'],
+      ['Justice Mccarthy', 'Attorney', 'Tucson', 26, '$330,000'],
+      ['Silver Carey', 'Computer Scientist', 'Memphis', 47, '$250,000'],
+      ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
+      ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
+      ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
+      ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
+    ]
+  };
+
+  // mock async function
+  xhrRequest = (url, filterList) => {
+    return new Promise(resolve => {
+      window.setTimeout(
+        () => {
+          var data = [
+            ['Gabby George', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
+            ['Aiden Lloyd', 'Business Consultant', 'Dallas', 55, '$200,000'],
+            ['Jaden Collins', 'Attorney', 'Santa Ana', 27, '$500,000'],
+            ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
+            ['Aaren Rose', 'Business Consultant', 'Toledo', 28, '$75,000'],
+            ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
+            ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
+            ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
+            ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
+            ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
+            ['Harper White', 'Attorney', 'Pittsburgh', 52, '$420,000'],
+            ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
+            ['Frankie Long', 'Industrial Analyst', 'Austin', 31, '$170,000'],
+            ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, '$90,000'],
+            ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000'],
+            ['Addison Navarro', 'Business Management Analyst', 'New York', 50, '$295,000'],
+            ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
+            ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
+            ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
+            ['Danny Leon', 'Computer Scientist', 'Newark', 60, '$220,000'],
+            ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
+            ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, '$99,000'],
+            ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
+            ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, '$140,000'],
+            ['Justice Mccarthy', 'Attorney', 'Tucson', 26, '$330,000'],
+            ['Silver Carey', 'Computer Scientist', 'Memphis', 47, '$250,000'],
+            ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
+            ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
+            ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
+            ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
+          ];
+
+          /*
+            This code simulates filtering that would occur on the back-end
+          */
+          var filteredData = data.filter(row => {
+            var ret = true;
+
+            for (var ii = 0; ii <= 4; ii++) {
+              if (filterList[ii].length) {
+                ret = ret && filterList[ii].filter(ff => {
+                  return row[ii] == ff;
+                }).length > 0;
+              }
+            }
+            return ret;
+          });
+          resolve({ data: filteredData });
+        },
+        2000
+      );
+    });
+  }
+
+  handleFilterSubmit = (applyFilters) => () => {
+    /*
+      applyFilters applies the selected filters to the table's internal filterList state.
+      The return value is the new master filterList for the table.
+    */
+    var filterList = applyFilters();
+    this.requestData(filterList);
+  };
+
+  requestData(filterList) {
+    this.setState({ isLoading: true, filters: filterList });
+
+    // fake async request
+    this.xhrRequest(`/myApiServer?filters=${filterList}`, filterList).then(res => {
+      this.setState({ isLoading: false, data: res.data });
+    });
+  }
+
+  render() {
+    const columns = [
+      {
+        name: 'Name',
+        options: {
+          filter: true,
+          filterList: this.state.filters[0],
+        },
+      },
+      {
+        label: 'Title',
+        name: 'Title',
+        options: {
+          filter: true,
+          filterList: this.state.filters[1],
+        },
+      },
+      {
+        name: 'Location',
+        options: {
+          filter: true,
+          filterList: this.state.filters[2],
+        },
+      },
+      {
+        name: 'Age',
+        options: {
+          filter: true,
+          filterList: this.state.filters[3],
+        },
+      },
+      {
+        name: 'Salary',
+        options: {
+          filter: true,
+          filterList: this.state.filters[4],
+        },
+      },
+    ];
+
+    const options = {
+      filter: true,
+      filterType: 'dropdown',
+      responsive: 'scrollMaxHeight',
+      serverSide: true,
+      confirmFilters: true,
+      onFilterDialogOpen: () => {
+        console.log('filter dialog opened');
+      },
+      onFilterDialogClose: () => {
+        console.log('filter dialog closed');
+      },
+      onFilterChange: (column, filterList, type) => {
+        if (type === 'chip') {
+          console.log('updating filters via chip');
+          this.requestData(filterList);
+        }
+        if (column === null) {
+          console.log('filters were reset');
+          this.requestData(filterList);
+        }
+      },
+      customFilterDialogFooter: (currentFilterList, applyFilters) => {
+        return (
+          <div style={{ marginTop: '40px' }}>
+            <Button variant="contained" onClick={this.handleFilterSubmit(applyFilters)}>Apply Filters*</Button>
+            <p><em>*(Simulates selecting "Chicago" from "Location")</em></p>
+          </div>
+        );
+      }
+    };
+
+    return (
+      <React.Fragment>
+        {this.state.isLoading && (
+          <div style={{ position: 'absolute', top: '50%', left: '50%' }}>
+            <CircularProgress />
+          </div>
+        )}
+        <MUIDataTable title={'ACME Employee list'} data={this.state.data} columns={columns} options={options} />
+      </React.Fragment>
+    );
+  }
+}
+
+export default Example;

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -15,6 +15,7 @@ import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
 
 export const defaultFilterStyles = theme => ({
   root: {
@@ -101,30 +102,67 @@ class TableFilter extends React.Component {
     classes: PropTypes.object,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      filterList: cloneDeep(props.filterList),
+    };
+  }
+
+  filterUpdate = (index, value, column, type, customUpdate) => {
+    let newFilterList = this.state.filterList.slice(0);
+    this.props.updateFilterByType(newFilterList, index, value, type, customUpdate);
+    this.setState({
+      filterList: newFilterList,
+    });
+  };
+
   handleCheckboxChange = (index, value, column) => {
-    this.props.onFilterUpdate(index, value, column, 'checkbox');
+    this.filterUpdate(index, value, column, 'checkbox');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'checkbox');
+    }
   };
 
   handleDropdownChange = (event, index, column) => {
     const labelFilterAll = this.props.options.textLabels.filter.all;
     const value = event.target.value === labelFilterAll ? [] : [event.target.value];
-    this.props.onFilterUpdate(index, value, column, 'dropdown');
+
+    this.filterUpdate(index, value, column, 'dropdown');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'dropdown');
+    }
   };
 
   handleMultiselectChange = (index, value, column) => {
-    this.props.onFilterUpdate(index, value, column, 'multiselect');
+    this.filterUpdate(index, value, column, 'multiselect');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'multiselect');
+    }
   };
 
   handleTextFieldChange = (event, index, column) => {
-    this.props.onFilterUpdate(index, event.target.value, column, 'textField');
+    this.filterUpdate(index, event.target.value, column, 'textField');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, event.target.value, column, 'textField');
+    }
   };
 
   handleCustomChange = (value, index, column) => {
-    this.props.onFilterUpdate(index, value, column.name, column.filterType);
+    this.filterUpdate(index, value, column.name, column.filterType);
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column.name, column.filterType);
+    }
   };
 
   renderCheckbox(column, index) {
-    const { classes, filterData, filterList } = this.props;
+    const { classes, filterData } = this.props;
+    const { filterList } = this.state;
 
     return (
       <GridListTile key={index} cols={2}>
@@ -166,7 +204,8 @@ class TableFilter extends React.Component {
   }
 
   renderSelect(column, index) {
-    const { classes, filterData, filterList, options } = this.props;
+    const { classes, filterData, options } = this.props;
+    const { filterList } = this.state;
     const textLabels = options.textLabels.filter;
 
     return (
@@ -194,7 +233,8 @@ class TableFilter extends React.Component {
   }
 
   renderTextField(column, index) {
-    const { classes, filterList } = this.props;
+    const { classes } = this.props;
+    const { filterList } = this.state;
 
     return (
       <GridListTile key={index} cols={1} classes={{ tile: classes.gridListTile }}>
@@ -211,7 +251,8 @@ class TableFilter extends React.Component {
   }
 
   renderMultiselect(column, index) {
-    const { classes, filterData, filterList } = this.props;
+    const { classes, filterData } = this.props;
+    const { filterList } = this.state;
 
     return (
       <GridListTile key={index} cols={1} classes={{ tile: classes.gridListTile }}>
@@ -246,7 +287,8 @@ class TableFilter extends React.Component {
   }
 
   renderCustomField(column, index) {
-    const { classes, filterList, options } = this.props;
+    const { classes, options } = this.props;
+    const { filterList } = this.state;
     const display =
       (column.filterOptions && column.filterOptions.display) ||
       (options.filterOptions && options.filterOptions.display);
@@ -264,6 +306,23 @@ class TableFilter extends React.Component {
       </GridListTile>
     );
   }
+
+  applyFilters = () => {
+    this.state.filterList.forEach((filter, index) => {
+      this.props.onFilterUpdate(index, filter, 'custom');
+    });
+    return this.state.filterList;
+  };
+
+  resetFilters = () => {
+    if (this.props.options.confirmFilters === true) {
+      this.setState({
+        filterList: cloneDeep(this.props.filterList),
+      });
+    } else {
+      this.props.onFilterReset();
+    }
+  };
 
   render() {
     const { classes, columns, options, onFilterReset, customFooter, filterList } = this.props;
@@ -287,7 +346,7 @@ class TableFilter extends React.Component {
               tabIndex={0}
               aria-label={textLabels.reset}
               data-testid={'filterReset-button'}
-              onClick={onFilterReset}>
+              onClick={this.resetFilters}>
               {textLabels.reset}
             </Button>
           </div>
@@ -309,7 +368,7 @@ class TableFilter extends React.Component {
             }
           })}
         </GridList>
-        {customFooter ? customFooter(filterList) : ''}
+        {customFooter ? customFooter(filterList, this.applyFilters) : ''}
       </div>
     );
   }

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -99,7 +99,7 @@ class TableFilterList extends React.Component {
 
     return (
       <div className={classes.root}>
-        {serverSide
+        {serverSide && serverSideFilterList
           ? serverSideFilterList.map((item, index) => {
               const filterListRenderersValue = filterListRenderers[index](item);
 

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -221,6 +221,7 @@ class TableToolbar extends React.Component {
       toggleViewColumn,
       title,
       tableRef,
+      updateFilterByType,
     } = this.props;
 
     const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
@@ -336,6 +337,7 @@ class TableToolbar extends React.Component {
                   filterData={filterData}
                   onFilterUpdate={filterUpdate}
                   onFilterReset={resetFilters}
+                  updateFilterByType={updateFilterByType}
                 />
               }
             />


### PR DESCRIPTION
I have a feeling this PR may take some convincing, but it has a lot of subtle benefits. Here's what it does: It adds an option called "confirmFilters" that defaults to false and works in conjunction with the customFilterDialogFooter option. If it's set to true, then filters from the Filter dialog won't be applied to the master filterList object unless "confirmed". The customFilterDialogFooter is updated to receive an "applyFilters" function that will apply the filters that are set in the filter dialog.

There are 2 main use cases:

* Server-side filtering - I'll go through how this is different from serverSideFilterList below.
* Filtering on tables with large data sets. 

I would have set this option up to work with the large-data-set example I created in another PR, but it's not available yet so I created another serverside-filtering example to show it in action. You may look at it and see that it's not too different from the existing one, but here are the benefits for a confirmFilters option over a serverSideFilterList: 

* It dovetails nicely with https://github.com/gregnb/mui-datatables/pull/1086. If these two PRs are accepted, then no management of filterLists will be needed for server-side filters.
* It allows for the "Reset" button to behave differently for filter confirmation. Instead of resetting to a blank state, a user can reset back to the initial state of the dialog (ie, the current state the filters are in). 
* It's simpler than serverSideFilterList and requires no management of a filterList.
* It's future-proof since it works with the existing filterList.
* It's backwards compatible and works along side serverSideFilterList.

I'm not advocating that serverSideFilterList be removed or deprecated (that would probably annoy people). I'm pointing these out since there's some overlap for these features for the first use-case. 