### PR TITLE
Fix for multiselect customFilterListOptions render

### DIFF
--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -122,21 +122,22 @@ class TableFilterList extends React.Component {
               return item.map((data, colIndex) => filterChip(index, data, colIndex));
             })
           : filterList.map((item, index) => {
-              const customFilterListRenderersValue = filterListRenderers[index](item);
-
-              if (columnNames[index].filterType === 'custom' && customFilterListRenderersValue) {
-                if (Array.isArray(customFilterListRenderersValue)) {
-                  return customFilterListRenderersValue.map((customFilterItem, customFilterItemIndex) =>
-                    customFilterChipMultiValue(
-                      customFilterItem,
-                      index,
-                      customFilterItemIndex,
-                      item,
-                      customFilterListRenderersValue,
-                    ),
-                  );
-                } else {
-                  return customFilterChipSingleValue(index, item);
+              if (columnNames[index].filterType === 'custom') {
+                const customFilterListRenderersValue = filterListRenderers[index](item);
+                if (customFilterListRenderersValue) {
+                  if (Array.isArray(customFilterListRenderersValue)) {
+                    return customFilterListRenderersValue.map((customFilterItem, customFilterItemIndex) =>
+                      customFilterChipMultiValue(
+                        customFilterItem,
+                        index,
+                        customFilterItemIndex,
+                        item,
+                        customFilterListRenderersValue,
+                      ),
+                    );
+                  } else {
+                    return customFilterChipSingleValue(index, item);
+                  }
                 }
               }
 


### PR DESCRIPTION
This fixes a bug where `customFilterOptions.render` gets called twice for non-custom filters that override render. For `multiselect`, this beaks, as one of them passes all optoins as array and the second calls it once per option.


Example that breaks with current `master` (just added custom filter render to customize-filer): https://gist.github.com/Legogris/e63efeb24b766a76a26221c03df0c404