### PR TITLE
Feature/issue 1063 responsive options and table height

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The component accepts the following props:
 |**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(filterList: array) => React Component`
 |**`elevation`**|number|4|Shadow depth applied to Paper component
 |**`caseSensitive `**|boolean|false|Enable/disable case sensitivity for search
-|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage) **('scroll' option has been deprecated in favor of `scrollMaxHeight`)**
+|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage), 'scrollFullHeightFullWidth' (same as 'scrollFullHeight' except that paper container wraps the table and the width takes the full browser window), 'stackedFullWidth' (same as stacked with the addition of the paper container changes with 'scrollFullHeightFullWidth') **('scroll' option has been deprecated in favor of `scrollMaxHeight`)**
 |**`rowsPerPage`**|number|10|Number of rows allowed per page
 |**`rowsPerPageOptions`**|array|[10,15,100]|Options to provide in pagination for number of rows a user can select
 |**`rowHover`**|boolean|true|Enable/disable hover style over rows

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -49,6 +49,7 @@ const defaultTableStyles = theme => ({
       overflow: 'hidden',
     },
   },
+  responsiveStackedFullWidth: {},
   caption: {
     position: 'absolute',
     left: '-3000px',
@@ -136,7 +137,7 @@ class MUIDataTable extends React.Component {
     ).isRequired,
     /** Options used to describe table */
     options: PropTypes.shape({
-      responsive: PropTypes.oneOf(['stacked', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth']),
+      responsive: PropTypes.oneOf(['stacked', 'stackedFullWidth', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth']),
       filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
       getTextLabels: PropTypes.func,
       pagination: PropTypes.bool,
@@ -337,9 +338,9 @@ class MUIDataTable extends React.Component {
       );
       this.options.selectableRows = this.options.selectableRows ? 'multiple' : 'none';
     }
-    if (['scrollMaxHeight', 'scrollFullHeight', 'stacked', 'scrollFullHeightFullWidth'].indexOf(this.options.responsive) === -1) {
+    if (['scrollMaxHeight', 'scrollFullHeight', 'stacked', 'stackedFullWidth', 'scrollFullHeightFullWidth'].indexOf(this.options.responsive) === -1) {
       console.error(
-        'Invalid option value for responsive. Please use string option: scrollMaxHeight | scrollFullHeight | stacked | scrollFullHeightFullWidth',
+        'Invalid option value for responsive. Please use string option: scrollMaxHeight | scrollFullHeight | stacked | stackedFullWidth | scrollFullHeightFullWidth',
       );
     }
     if (this.options.responsive === 'scroll') {
@@ -1358,6 +1359,11 @@ class MUIDataTable extends React.Component {
         break;
       case 'stacked':
         responsiveClass = classes.responsiveStacked;
+        maxHeight = 'none';
+        break;
+      case 'stackedFullWidth':
+        responsiveClass = classes.responsiveStackedFullWidth;
+        paperClasses = `${classes.paperResponsiveScrollFullHeightFullWidth} ${className}`;
         maxHeight = 'none';
         break;
     }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -22,6 +22,9 @@ import { buildMap, getCollatorComparator, sortCompare, getPageValue } from './ut
 const defaultTableStyles = theme => ({
   root: {},
   paper: {},
+  paperResponsiveScrollFullHeightFullWidth: {
+    position: 'absolute'
+  },
   tableRoot: {
     outline: 'none',
   },
@@ -133,7 +136,7 @@ class MUIDataTable extends React.Component {
     ).isRequired,
     /** Options used to describe table */
     options: PropTypes.shape({
-      responsive: PropTypes.oneOf(['stacked', 'scrollMaxHeight', 'scrollFullHeight']),
+      responsive: PropTypes.oneOf(['stacked', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth']),
       filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
       getTextLabels: PropTypes.func,
       pagination: PropTypes.bool,
@@ -334,9 +337,9 @@ class MUIDataTable extends React.Component {
       );
       this.options.selectableRows = this.options.selectableRows ? 'multiple' : 'none';
     }
-    if (['scrollMaxHeight', 'scrollFullHeight', 'stacked'].indexOf(this.options.responsive) === -1) {
+    if (['scrollMaxHeight', 'scrollFullHeight', 'stacked', 'scrollFullHeightFullWidth'].indexOf(this.options.responsive) === -1) {
       console.error(
-        'Invalid option value for responsive. Please use string option: scrollMaxHeight | scrollFullHeight | stacked',
+        'Invalid option value for responsive. Please use string option: scrollMaxHeight | scrollFullHeight | stacked | scrollFullHeightFullWidth',
       );
     }
     if (this.options.responsive === 'scroll') {
@@ -1330,10 +1333,12 @@ class MUIDataTable extends React.Component {
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
     const showToolbar = hasToolbarItem(this.options, title);
     const columnNames = columns.map(column => ({ name: column.name, filterType: column.filterType }));
+    const responsiveOption = this.options.responsive;
+    let paperClasses = `${classes.paper} ${className}`;
     let maxHeight;
     let responsiveClass;
 
-    switch (this.options.responsive) {
+    switch (responsiveOption) {
       // DEPRECATED: This options is beign transitioned to `responsiveScrollMaxHeight`
       case 'scroll':
         responsiveClass = classes.responsiveScroll;
@@ -1346,6 +1351,10 @@ class MUIDataTable extends React.Component {
       case 'scrollFullHeight':
         responsiveClass = classes.responsiveScrollFullHeight;
         maxHeight = 'none';
+        break;
+      case 'scrollFullHeightFullWidth':
+        responsiveClass = classes.responsiveScrollFullHeight;
+        paperClasses = `${classes.paperResponsiveScrollFullHeightFullWidth} ${className}`;
         break;
       case 'stacked':
         responsiveClass = classes.responsiveStacked;
@@ -1361,7 +1370,7 @@ class MUIDataTable extends React.Component {
       <Paper
         elevation={this.options.elevation}
         ref={this.tableContent}
-        className={classnames(classes.paper, className)}>
+        className={paperClasses}>
         {selectedRows.data.length && this.options.disableToolbarSelect !== true ? (
           <TableToolbarSelect
             options={this.options}

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -29,17 +29,14 @@ const defaultTableStyles = theme => ({
     overflowX: 'auto',
     overflow: 'auto',
     height: '100%',
-    maxHeight: '499px',
   },
   responsiveScrollMaxHeight: {
     overflowX: 'auto',
     overflow: 'auto',
     height: '100%',
-    maxHeight: '499px',
   },
   responsiveScrollFullHeight: {
     height: '100%',
-    maxHeight: 'none',
   },
   responsiveStacked: {
     overflowX: 'auto',
@@ -1333,21 +1330,26 @@ class MUIDataTable extends React.Component {
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
     const showToolbar = hasToolbarItem(this.options, title);
     const columnNames = columns.map(column => ({ name: column.name, filterType: column.filterType }));
+    let maxHeight;
     let responsiveClass;
 
     switch (this.options.responsive) {
       // DEPRECATED: This options is beign transitioned to `responsiveScrollMaxHeight`
       case 'scroll':
         responsiveClass = classes.responsiveScroll;
+        maxHeight = '499px';
         break;
       case 'scrollMaxHeight':
         responsiveClass = classes.responsiveScrollMaxHeight;
+        maxHeight = '499px';
         break;
       case 'scrollFullHeight':
         responsiveClass = classes.responsiveScrollFullHeight;
+        maxHeight = 'none';
         break;
       case 'stacked':
         responsiveClass = classes.responsiveStacked;
+        maxHeight = 'none';
         break;
     }
 
@@ -1408,7 +1410,7 @@ class MUIDataTable extends React.Component {
           filterUpdate={this.filterUpdate}
           columnNames={columnNames}
         />
-        <div style={{ position: 'relative' }} className={responsiveClass}>
+        <div style={{ position: 'relative', maxHeight }} className={responsiveClass}>
           {this.options.resizableColumns && (
             <TableResize
               key={rowCount}

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -65,9 +65,10 @@ class TableBodyCell extends React.Component {
           {
             [classes.root]: true,
             [classes.cellHide]: true,
-            [classes.stackedCommon]: options.responsive === 'stacked',
+            [classes.stackedCommon]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
             [classes.cellStackedSmall]:
-              options.responsive === 'stacked' &&
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth' &&
               (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small'),
             'datatables-noprint': !print,
           },
@@ -81,9 +82,10 @@ class TableBodyCell extends React.Component {
         className={classNames(
           {
             [classes.root]: true,
-            [classes.stackedCommon]: options.responsive === 'stacked',
+            [classes.stackedCommon]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
             [classes.responsiveStackedSmall]:
-              options.responsive === 'stacked' &&
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth' &&
               (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small'),
             'datatables-noprint': !print,
           },

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -39,7 +39,7 @@ class TableBodyRow extends React.Component {
             [classes.root]: true,
             [classes.hover]: options.rowHover,
             [classes.hoverCursor]: options.selectableRowsOnClick || options.expandableRowsOnClick,
-            [classes.responsiveStacked]: options.responsive === 'stacked',
+            [classes.responsiveStacked]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
           },
           className,
         )}

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -57,7 +57,7 @@ class TableHead extends React.Component {
 
     return (
       <MuiTableHead
-        className={classNames({ [classes.responsiveStacked]: options.responsive === 'stacked', [classes.main]: true })}>
+        className={classNames({ [classes.responsiveStacked]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth', [classes.main]: true })}>
         <TableHeadRow>
           <TableSelectCell
             ref={el => setCellRef(0, findDOMNode(el))}

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -20,15 +20,26 @@ import cloneDeep from 'lodash.clonedeep';
 
 export const defaultToolbarStyles = theme => ({
   root: {},
+  fullWidthRoot: {},
   left: {
+    flex: '1 1 auto',
+  },
+  fullWidthLeft: {
     flex: '1 1 auto',
   },
   actions: {
     flex: '1 1 auto',
     textAlign: 'right',
   },
+  fullWidthActions: {
+    flex: '1 1 auto',
+    textAlign: 'right',
+  },
   titleRoot: {},
   titleText: {},
+  fullWidthTitleText: {
+    textAlign: 'left',
+  },
   icon: {
     '&:hover': {
       color: theme.palette.primary.main,
@@ -78,6 +89,8 @@ export const defaultToolbarStyles = theme => ({
   },
   '@media screen and (max-width: 480px)': {},
 });
+
+const RESPONSIVE_FULL_WIDTH_NAME = 'scrollFullHeightFullWidth';
 
 class TableToolbar extends React.Component {
   state = {
@@ -227,8 +240,8 @@ class TableToolbar extends React.Component {
     const { showSearch, searchText } = this.state;
 
     return (
-      <Toolbar className={classes.root} role={'toolbar'} aria-label={'Table Toolbar'}>
-        <div className={classes.left}>
+      <Toolbar className={options.responsive !== RESPONSIVE_FULL_WIDTH_NAME ? classes.root : classes.fullWidthRoot} role={'toolbar'} aria-label={'Table Toolbar'}>
+        <div className={options.responsive !== RESPONSIVE_FULL_WIDTH_NAME ? classes.left : classes.fullWidthLeft}>
           {showSearch === true ? (
             options.customSearchRender ? (
               options.customSearchRender(searchText, this.handleSearch, this.hideSearch, options)
@@ -244,13 +257,13 @@ class TableToolbar extends React.Component {
             title
           ) : (
             <div className={classes.titleRoot} aria-hidden={'true'}>
-              <Typography variant="h6" className={classes.titleText}>
+              <Typography variant="h6" className={options.responsive !== RESPONSIVE_FULL_WIDTH_NAME ? classes.titleText : classes.fullWidthTitleText}>
                 {title}
               </Typography>
             </div>
           )}
         </div>
-        <div className={classes.actions}>
+        <div className={options.responsive !== RESPONSIVE_FULL_WIDTH_NAME ? classes.actions : classes.fullWidthActions}>
           {options.search && (
             <Tooltip title={search} disableFocusListener>
               <IconButton


### PR DESCRIPTION
Closes https://github.com/gregnb/mui-datatables/pull/1075, https://github.com/gregnb/mui-datatables/issues/1063 and continues by adding two new options for responsive cases:

- scrollFullHeightFullWidth
- stackedFullWidth

Both use absolute position on the paper container element to allow window width to be surrounded by the container to fix visual breakage with overflowing widths, but also allow fixed header options to operate.

Height was decoupled in the code, but not created as a separate option as height will only be supported by certain responsive modes, which is likely to create confusion. Overriding styles allows altering height values, so this functionality exists regardless, but the decoupling will make it easier to modify the API in the future if there's a good way to do so.