### PR TITLE
Fix for Issue #1152 Table Search Accessibility

### DIFF
--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -55,8 +55,10 @@ class TableSearch extends React.Component {
           <TextField
             className={classes.searchText}
             autoFocus={true}
-            inputProps={{
+            InputProps={{
               'data-test-id': options.textLabels.toolbar.search,
+            }}
+            inputProps={{
               'aria-label': options.textLabels.toolbar.search,
             }}
             value={searchText || ''}

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -55,7 +55,7 @@ class TableSearch extends React.Component {
           <TextField
             className={classes.searchText}
             autoFocus={true}
-            InputProps={{
+            inputProps={{
               'data-test-id': options.textLabels.toolbar.search,
               'aria-label': options.textLabels.toolbar.search,
             }}


### PR DESCRIPTION
Move props from the `div` to the `input`

Fixing the Accessibility issue with the input not having an appropriate aria-label.