### PR TITLE
Prevent skipping of heading level for Accessibility and standard semantic HTML purposes

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -280,8 +280,8 @@ class TableBody extends React.Component {
               options={options}
               colIndex={0}
               rowIndex={0}>
-              <Typography variant="subtitle1" className={classes.emptyTitle}>
-                {options.textLabels.body.noMatch}
+              <Typography variant="body1" className={classes.emptyTitle}>
+                <strong>{options.textLabels.body.noMatch}</strong>
               </Typography>
             </TableBodyCell>
           </TableBodyRow>


### PR DESCRIPTION
Change Typography from `h6` to `p`.
Put text inside `strong` to keep emphasis and bold text.
http://web-accessibility.carnegiemuseums.org/foundations/semantic/