### PR TITLE
Allow to pass custom table components

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The component accepts the following props:
 |**`columns`**|array|Columns used to describe table. Must be either an array of simple strings or objects describing a column
 |**`data`**|array|Data used to describe table. Must be either an array containing objects of key/value pairs with values that are strings or numbers, or arrays of strings or numbers (Ex: data: [{"Name": "Joe", "Job Title": "Plumber", "Age": 30}, {"Name": "Jane", "Job Title": "Electrician", "Age": 45}] or data: [["Joe", "Plumber", 30], ["Jane", "Electrician", 45]]) **Use of arbitrary objects as data is not supported, and is deprecated. Consider using ids and mapping to external object data in custom renderers instead e.g. `const data = [{"Name": "Joe", "ObjectData": 123}] --> const dataToMapInCustomRender = { 123: { foo: 'bar', baz: 'qux', ... } }`**
 |**`options`**|object|Options used to describe table
+|**`components`**|object|Custom components used to render the table
 
 #### Options:
 |Name|Type|Default|Description
@@ -325,6 +326,52 @@ class BodyCellExample extends React.Component {
 }
 
 ```
+
+## Custom Components
+
+You can pass custom components to further customize the table:
+```js
+import React from "react";
+import Chip from '@material-ui/core/Chip';
+import MUIDataTable, { TableFilterList } from "mui-datatables";
+
+const CustomChip = ({ label, onDelete }) => {
+    return (
+        <Chip
+            variant="outlined"
+            color="secondary"
+            label={label}
+            onDelete={onDelete}
+        />
+    );
+};
+
+const CustomFilterList = (props) => {
+    return <TableFilterList {...props} ItemComponent={CustomChip} />;
+};
+
+class CustomDataTable extends React.Component {
+    render() {
+        return (
+            <MUIDataTable
+                columns={columns}
+                data={data}
+                components={{
+                  TableFilterList: CustomFilterList,
+                }}
+            />
+        );
+    }
+}
+```
+Supported customizable components:
+ * `TableBody`
+ * `TableFilterList` - you can pass `ItemComponent` prop to render custom filter list item
+ * `TableFooter`
+ * `TableHead`
+ * `TableResize`
+ * `TableToolbar`
+ * `TableToolbarSelect`
 
 ## Remote Data
 

--- a/examples/custom-components/index.js
+++ b/examples/custom-components/index.js
@@ -6,11 +6,11 @@ import MenuItem from '@material-ui/core/MenuItem';
 import TableFilterList from '../../src/components/TableFilterList';
 
 const CustomChip = (props) => {
-  const { label, onDelete, column, className } = props;
+  const { label, onDelete, columnNames, className, index } = props;
   return (<Chip
       className={className}
       variant="outlined"
-      color={column === 'Company' ? 'secondary' : 'primary'}
+      color={columnNames[index].name === 'Company' ? 'secondary' : 'primary'}
       label={label}
       onDelete={onDelete}
   />);

--- a/examples/custom-components/index.js
+++ b/examples/custom-components/index.js
@@ -5,10 +5,12 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import TableFilterList from '../../src/components/TableFilterList';
 
-const CustomChip = ({ label, onDelete }) => {
+const CustomChip = (props) => {
+  const { label, onDelete, column, className } = props;
   return (<Chip
+      className={className}
       variant="outlined"
-      color="secondary"
+      color={column === 'Company' ? 'secondary' : 'primary'}
       label={label}
       onDelete={onDelete}
   />);
@@ -61,7 +63,7 @@ class Example extends React.Component {
           },
         },
       },
-      { name: 'City', label: 'City Label' },
+      { name: 'City', label: 'City Label', options: { filterList: ['Dallas'] } },
       { name: 'State' },
       { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
     ];

--- a/examples/custom-components/index.js
+++ b/examples/custom-components/index.js
@@ -1,0 +1,89 @@
+import React from "react";
+import MUIDataTable from "../../src/";
+import Chip from '@material-ui/core/Chip';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import TableFilterList from '../../src/components/TableFilterList';
+
+const CustomChip = ({ label, onDelete }) => {
+  return (<Chip
+      variant="outlined"
+      color="secondary"
+      label={label}
+      onDelete={onDelete}
+  />);
+};
+
+const CustomFilterList = (props) => {
+  return <TableFilterList {...props} ItemComponent={CustomChip} />;
+};
+
+class Example extends React.Component {
+
+  render() {
+    const columns = [
+      { name: 'Name' },
+      {
+        name: 'Company',
+        options: {
+          filter: true,
+          filterType: 'custom',
+          filterList: ['Test Corp'],
+          customFilterListOptions: {
+            render: v => {
+              if (v.length !== 0) {
+                return `Company: ${v[0]}`;
+              }
+              return false;
+            },
+            update: (filterList) => filterList,
+          },
+          filterOptions: {
+            names: [],
+            logic(status, filter) {
+              if (filter.length > 0) {
+                return status !== filter[0];
+              }
+              return false;
+            },
+            display: (filterList, onChange, index, column) => (
+                <Select
+                    onChange={event => {
+                      filterList[index][0] = event.target.value;
+                      onChange(filterList[index], index, column);
+                    }}
+                    value={filterList[index]}
+                >
+                  <MenuItem value="Test Corp">{'Test Corp'}</MenuItem>
+                  <MenuItem value="Other Corp">{'Other Corp'}</MenuItem>
+                </Select>
+            )
+          },
+        },
+      },
+      { name: 'City', label: 'City Label' },
+      { name: 'State' },
+      { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
+    ];
+    const data = [
+      ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
+      ['John Walsh', 'Test Corp', 'Hartford', null],
+      ['Bob Herm', 'Other Corp', 'Tampa', 'FL'],
+      ['James Houston', 'Test Corp', 'Dallas', 'TX'],
+    ];
+
+    return (
+      <MUIDataTable
+          title={"ACME Employee list"}
+          data={data}
+          columns={columns}
+          components={{
+            TableFilterList: CustomFilterList,
+          }}
+      />
+    );
+
+  }
+}
+
+export default Example;

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -29,6 +29,7 @@ import ServerSideSorting from './serverside-sorting';
 import Simple from './simple';
 import SimpleNoToolbar from './simple-no-toolbar';
 import TextLocalization from './text-localization';
+import CustomComponents from './custom-components';
 import Themes from './themes';
 
 /**
@@ -66,5 +67,6 @@ export default {
   Simple: Simple,
   'Simple No Toolbar': SimpleNoToolbar,
   'Text Localization': TextLocalization,
+  'Custom Components': CustomComponents,
   Themes: Themes,
 };

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -9,13 +9,13 @@ import isUndefined from 'lodash.isundefined';
 import merge from 'lodash.merge';
 import PropTypes from 'prop-types';
 import React from 'react';
-import TableBody from './components/TableBody';
-import TableFilterList from './components/TableFilterList';
-import TableFooter from './components/TableFooter';
-import TableHead from './components/TableHead';
-import TableResize from './components/TableResize';
-import TableToolbar from './components/TableToolbar';
-import TableToolbarSelect from './components/TableToolbarSelect';
+import DefaultTableBody from './components/TableBody';
+import DefaultTableFilterList from './components/TableFilterList';
+import DefaultTableFooter from './components/TableFooter';
+import DefaultTableHead from './components/TableHead';
+import DefaultTableResize from './components/TableResize';
+import DefaultTableToolbar from './components/TableToolbar';
+import DefaultTableToolbarSelect from './components/TableToolbarSelect';
 import getTextLabels from './textLabels';
 import { buildMap, getCollatorComparator, sortCompare, getPageValue, warnDeprecated } from './utils';
 
@@ -210,6 +210,7 @@ class MUIDataTable extends React.Component {
     }),
     /** Pass and use className to style MUIDataTable as desired */
     className: PropTypes.string,
+    components: PropTypes.objectOf(PropTypes.any),
   };
 
   static defaultProps = {
@@ -217,6 +218,15 @@ class MUIDataTable extends React.Component {
     options: {},
     data: [],
     columns: [],
+    components: {
+      TableBody: DefaultTableBody,
+      TableFilterList: DefaultTableFilterList,
+      TableFooter: DefaultTableFooter,
+      TableHead: DefaultTableHead,
+      TableResize: DefaultTableResize,
+      TableToolbar: DefaultTableToolbar,
+      TableToolbarSelect: DefaultTableToolbarSelect,
+    },
   };
 
   state = {
@@ -1331,7 +1341,20 @@ class MUIDataTable extends React.Component {
   }
 
   render() {
-    const { classes, className, title } = this.props;
+    const {
+      classes,
+      className,
+      title,
+      components: {
+        TableBody,
+        TableFilterList,
+        TableFooter,
+        TableHead,
+        TableResize,
+        TableToolbar,
+        TableToolbarSelect,
+      }
+    } = this.props;
     const {
       announceText,
       activeColumn,
@@ -1347,6 +1370,14 @@ class MUIDataTable extends React.Component {
       searchText,
       serverSideFilterList,
     } = this.state;
+
+    const TableBodyComponent = TableBody || DefaultTableBody;
+    const TableFilterListComponent = TableFilterList || DefaultTableFilterList;
+    const TableFooterComponent = TableFooter || DefaultTableFooter;
+    const TableHeadComponent = TableHead || DefaultTableHead;
+    const TableResizeComponent = TableResize || DefaultTableResize;
+    const TableToolbarComponent = TableToolbar || DefaultTableToolbar;
+    const TableToolbarSelectComponent = TableToolbarSelect || DefaultTableToolbarSelect;
 
     const rowCount = this.state.count || displayData.length;
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
@@ -1396,7 +1427,7 @@ class MUIDataTable extends React.Component {
     return (
       <Paper elevation={this.options.elevation} ref={this.tableContent} className={paperClasses}>
         {selectedRows.data.length && this.options.disableToolbarSelect !== true ? (
-          <TableToolbarSelect
+          <TableToolbarSelectComponent
             options={this.options}
             selectedRows={selectedRows}
             onRowsDelete={this.selectRowDelete}
@@ -1405,7 +1436,7 @@ class MUIDataTable extends React.Component {
           />
         ) : (
           showToolbar && (
-            <TableToolbar
+            <TableToolbarComponent
               columns={columns}
               displayData={displayData}
               data={data}
@@ -1424,7 +1455,7 @@ class MUIDataTable extends React.Component {
             />
           )
         )}
-        <TableFilterList
+        <TableFilterListComponent
           options={this.options}
           serverSideFilterList={this.props.options.serverSideFilterList || []}
           filterListRenderers={columns.map(c => {
@@ -1445,7 +1476,7 @@ class MUIDataTable extends React.Component {
         />
         <div style={{ position: 'relative', maxHeight }} className={responsiveClass}>
           {this.options.resizableColumns && (
-            <TableResize
+            <TableResizeComponent
               key={rowCount}
               updateDividers={fn => (this.updateDividers = fn)}
               setResizeable={fn => (this.setHeadResizeable = fn)}
@@ -1458,7 +1489,7 @@ class MUIDataTable extends React.Component {
             className={tableClassNames}
             {...tableProps}>
             <caption className={classes.caption}>{title}</caption>
-            <TableHead
+            <TableHeadComponent
               columns={columns}
               activeColumn={activeColumn}
               data={displayData}
@@ -1472,7 +1503,7 @@ class MUIDataTable extends React.Component {
               setCellRef={this.setHeadCellRef}
               options={this.options}
             />
-            <TableBody
+            <TableBodyComponent
               data={displayData}
               count={rowCount}
               columns={columns}
@@ -1488,7 +1519,7 @@ class MUIDataTable extends React.Component {
             />
           </MuiTable>
         </div>
-        <TableFooter
+        <TableFooterComponent
           options={this.options}
           page={page}
           rowCount={rowCount}

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1345,15 +1345,7 @@ class MUIDataTable extends React.Component {
       classes,
       className,
       title,
-      components: {
-        TableBody,
-        TableFilterList,
-        TableFooter,
-        TableHead,
-        TableResize,
-        TableToolbar,
-        TableToolbarSelect,
-      }
+      components: { TableBody, TableFilterList, TableFooter, TableHead, TableResize, TableToolbar, TableToolbarSelect },
     } = this.props;
     const {
       announceText,

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -1,7 +1,7 @@
-import Chip from '@material-ui/core/Chip';
 import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import React from 'react';
+import TableFilterListItem from './TableFilterListItem';
 
 const defaultFilterListStyles = {
   root: {
@@ -32,6 +32,11 @@ class TableFilterList extends React.Component {
     onFilterUpdate: PropTypes.func,
     /** Extend the style applied to components */
     classes: PropTypes.object,
+    ItemComponent: PropTypes.any,
+  };
+
+  static defaultProps = {
+    ItemComponent: TableFilterListItem,
   };
 
   render() {
@@ -43,6 +48,7 @@ class TableFilterList extends React.Component {
       columnNames,
       serverSideFilterList,
       customFilterListUpdate,
+      ItemComponent,
     } = this.props;
     const { serverSide } = this.props.options;
 
@@ -55,7 +61,7 @@ class TableFilterList extends React.Component {
       else type = columnNames[index].filterType;
 
       return (
-        <Chip
+        <ItemComponent
           label={customFilterItem}
           key={customFilterItemIndex}
           onDelete={filterUpdate.bind(
@@ -67,16 +73,22 @@ class TableFilterList extends React.Component {
             customFilterListUpdate[index],
           )}
           className={classes.chip}
+          itemKey={customFilterItemIndex}
+          index={index}
+          data={item}
         />
       );
     };
 
     const filterChip = (index, data, colIndex) => (
-      <Chip
+      <ItemComponent
         label={filterListRenderers[index](data)}
         key={colIndex}
         onDelete={filterUpdate.bind(null, index, data, columnNames[index].name, 'chip')}
         className={classes.chip}
+        itemKey={colIndex}
+        index={index}
+        data={data}
       />
     );
 

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -76,7 +76,7 @@ class TableFilterList extends React.Component {
           itemKey={customFilterItemIndex}
           index={index}
           data={item}
-          column={columnNames[index].name}
+          columnNames={columnNames}
         />
       );
     };
@@ -90,7 +90,7 @@ class TableFilterList extends React.Component {
         itemKey={colIndex}
         index={index}
         data={data}
-        column={columnNames[index].name}
+        columnNames={columnNames}
       />
     );
 

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -76,6 +76,7 @@ class TableFilterList extends React.Component {
           itemKey={customFilterItemIndex}
           index={index}
           data={item}
+          column={columnNames[index].name}
         />
       );
     };
@@ -89,6 +90,7 @@ class TableFilterList extends React.Component {
         itemKey={colIndex}
         index={index}
         data={data}
+        column={columnNames[index].name}
       />
     );
 

--- a/src/components/TableFilterListItem.js
+++ b/src/components/TableFilterListItem.js
@@ -3,27 +3,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class TableFilterListItem extends React.PureComponent {
-    static propTypes = {
-        label: PropTypes.node,
-        onDelete: PropTypes.func.isRequired,
-        className: PropTypes.string.isRequired,
-    };
+  static propTypes = {
+    label: PropTypes.node,
+    onDelete: PropTypes.func.isRequired,
+    className: PropTypes.string.isRequired,
+  };
 
-    render() {
-        const {
-            label,
-            onDelete,
-            className,
-        } = this.props;
+  render() {
+    const { label, onDelete, className } = this.props;
 
-        return (
-            <Chip
-                label={label}
-                onDelete={onDelete}
-                className={className}
-            />
-        );
-    }
+    return <Chip label={label} onDelete={onDelete} className={className} />;
+  }
 }
 
 export default TableFilterListItem;

--- a/src/components/TableFilterListItem.js
+++ b/src/components/TableFilterListItem.js
@@ -1,0 +1,29 @@
+import Chip from '@material-ui/core/Chip';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class TableFilterListItem extends React.PureComponent {
+    static propTypes = {
+        label: PropTypes.node,
+        onDelete: PropTypes.func.isRequired,
+        className: PropTypes.string.isRequired,
+    };
+
+    render() {
+        const {
+            label,
+            onDelete,
+            className,
+        } = this.props;
+
+        return (
+            <Chip
+                label={label}
+                onDelete={onDelete}
+                className={className}
+            />
+        );
+    }
+}
+
+export default TableFilterListItem;

--- a/test/MUIDataTableCustomComponents.test.js
+++ b/test/MUIDataTableCustomComponents.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import MUIDataTable from '../src/MUIDataTable';
+import Chip from '@material-ui/core/Chip';
+import TableFilterList from '../src/components/TableFilterList';
+
+const CustomChip = (props) => {
+  return <Chip variant="outlined" color="secondary" label={props.label} />;
+};
+
+const CustomFilterList = (props) => {
+  return <TableFilterList {...props} ItemComponent={CustomChip} />;
+};
+
+describe('<MUIDataTable /> with custom components', function() {
+  let data;
+  let columns;
+
+  before(() => {
+    columns = [
+      { name: 'Name' },
+      {
+        name: 'Company',
+        options: {
+          filter: true,
+          filterType: 'custom',
+          filterList: ['Test Corp'],
+        },
+      },
+      { name: 'City', label: 'City Label' },
+      { name: 'State' },
+      { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
+    ];
+    data = [
+      ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
+      ['John Walsh', 'Test Corp', 'Hartford', null],
+      ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
+      ['James Houston', 'Test Corp', 'Dallas', 'TX'],
+    ];
+  });
+
+  it('should render a table with custom Chip in TableFilterList', () => {
+    const shallowWrapper = shallow(
+        <MUIDataTable
+            columns={columns}
+            data={data}
+            components={{
+              TableFilterList: CustomFilterList,
+            }}
+        />);
+    const customFilterList = shallowWrapper.dive().find(CustomFilterList);
+    assert.lengthOf(customFilterList, 1);
+    const customChip = customFilterList.dive().dive().dive().find(CustomChip);
+    assert.lengthOf(customChip, 1);
+  });
+});

--- a/test/MUIDataTableCustomComponents.test.js
+++ b/test/MUIDataTableCustomComponents.test.js
@@ -5,11 +5,11 @@ import MUIDataTable from '../src/MUIDataTable';
 import Chip from '@material-ui/core/Chip';
 import TableFilterList from '../src/components/TableFilterList';
 
-const CustomChip = (props) => {
+const CustomChip = props => {
   return <Chip variant="outlined" color="secondary" label={props.label} />;
 };
 
-const CustomFilterList = (props) => {
+const CustomFilterList = props => {
   return <TableFilterList {...props} ItemComponent={CustomChip} />;
 };
 
@@ -42,16 +42,21 @@ describe('<MUIDataTable /> with custom components', function() {
 
   it('should render a table with custom Chip in TableFilterList', () => {
     const shallowWrapper = shallow(
-        <MUIDataTable
-            columns={columns}
-            data={data}
-            components={{
-              TableFilterList: CustomFilterList,
-            }}
-        />);
+      <MUIDataTable
+        columns={columns}
+        data={data}
+        components={{
+          TableFilterList: CustomFilterList,
+        }}
+      />,
+    );
     const customFilterList = shallowWrapper.dive().find(CustomFilterList);
     assert.lengthOf(customFilterList, 1);
-    const customChip = customFilterList.dive().dive().dive().find(CustomChip);
+    const customChip = customFilterList
+      .dive()
+      .dive()
+      .dive()
+      .find(CustomChip);
     assert.lengthOf(customChip, 1);
   });
 });


### PR DESCRIPTION
Currently there is no way to change built-in table components. This PR enables some customization.
This is a bit different that customizing with custom Material theme as this allows to react to given props.

In example: you can change the color of `Chip` in `TableFilterList` depending on current value. Useful for filtering by some status-like fields - you will have one `Chip` indicating status with visual feedback in filter list instead of duplicating this feedback throughout entire table.

![image](https://user-images.githubusercontent.com/7325630/73050693-55413580-3e89-11ea-8a5e-691ce8493239.png)

