### PR TITLE
Move keydown close event to element

### DIFF
--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -6,6 +6,8 @@ import IconButton from '@material-ui/core/IconButton';
 import ClearIcon from '@material-ui/icons/Clear';
 import { withStyles } from '@material-ui/core/styles';
 
+const ESC_KEY_CODE = 27;
+
 const defaultSearchStyles = theme => ({
   main: {
     display: 'flex',
@@ -31,16 +33,8 @@ class TableSearch extends React.Component {
     this.props.onSearch(event.target.value);
   };
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.onKeyDown, false);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.onKeyDown, false);
-  }
-
   onKeyDown = event => {
-    if (event.keyCode === 27) {
+    if (event.keyCode === ESC_KEY_CODE) {
       this.props.onHide();
     }
   };
@@ -62,6 +56,7 @@ class TableSearch extends React.Component {
               'aria-label': options.textLabels.toolbar.search,
             }}
             value={searchText || ''}
+            onKeyDown={this.onKeyDown}
             onChange={this.handleTextChange}
             fullWidth={true}
             inputRef={el => (this.searchField = el)}


### PR DESCRIPTION
Keeps the listener off of the document for better UX.

Closes https://github.com/gregnb/mui-datatables/issues/1203.