### PR TITLE
Prevent search icon focus on close

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -217,8 +217,6 @@ class TableToolbar extends React.Component {
       showSearch: false,
       searchText: null,
     }));
-
-    this.searchButton.focus();
   };
 
   handleSearch = value => {


### PR DESCRIPTION
Fixes issue where closing via keydown causes the icon to become focused, which is confusing behavior