### PR TITLE
fix webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: {
     app: "./examples/Router/index.js"
   },
-  stats: "verbose",
+  stats: 'verbose',
   context: __dirname,
   output: {
     filename: 'bundle.js'
@@ -12,10 +12,11 @@ module.exports = {
   devtool: 'source-map',
   devServer: {
     disableHostCheck: true,
+    host: 'localhost',
     hot: true,
     inline: true,
-    host: "0.0.0.0",
-    port: 5050
+    port: 5050,
+    stats: 'errors-warnings'
   },
   module: {
     rules: [


### PR DESCRIPTION
Build has too many logs. 😭 
So reduce the log... change stats options(errors-warings)
ref : https://webpack.js.org/configuration/stats/

devserver host set localhost #1042 

+ remove unused import (path)

What do you think?

thanks~

