### PR TITLE
Fixed issues with "responsive" option, added tableBodyHeight and tableBodyMaxHeight options, added new responsive mode "simple"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![dependencies Status](https://david-dm.org/gregnb/mui-datatables/status.svg)](https://david-dm.org/gregnb/mui-datatables)
 [![npm version](https://badge.fury.io/js/mui-datatables.svg)](https://badge.fury.io/js/mui-datatables)
 
-MUI-Datatables is a data tables component built on [Material-UI](https://www.material-ui.com).  It comes with features like filtering, resizable + view/hide columns, search, export to CSV download, printing, selectable rows, expandable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are three responsive modes "stacked", "scrollMaxHeight", and "scrollFullHeight" for mobile/tablet devices.
+MUI-Datatables is a data tables component built on [Material-UI](https://www.material-ui.com).  It comes with features like filtering, resizable + view/hide columns, search, export to CSV download, printing, selectable rows, expandable rows, pagination, and sorting. On top of the ability to customize styling on most views, there are three responsive modes "vertical", "standard", and "simple" for mobile/tablet devices.
 
 <div align="center">
 	<img src="https://user-images.githubusercontent.com/19170080/38026128-eac9d506-3258-11e8-92a7-b0d06e5faa82.gif" />
@@ -180,7 +180,7 @@ The component accepts the following props:
 |**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(filterList: array) => React Component`
 |**`elevation`**|number|4|Shadow depth applied to Paper component
 |**`caseSensitive `**|boolean|false|Enable/disable case sensitivity for search
-|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage), 'scrollFullHeightFullWidth' (same as 'scrollFullHeight' except that paper container wraps the table and the width takes the full browser window), 'stackedFullWidth' (same as stacked with the addition of the paper container changes with 'scrollFullHeightFullWidth') **('scroll' option has been deprecated in favor of `scrollMaxHeight`)**
+|**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: <p><ul><li>"vertical" (default value): In smaller views the table cells will collapse such that the heading is to the left of the cell value.</li><li>"standard": Table will stay in the standard mode but make small changes to better fit the allocated space.<li>"simple": On very small devices the table rows will collapse into simple display.</li></ul></p>[Example](https://github.com/gregnb/mui-datatables/blob/master/examples/simple/index.js)
 |**`rowsPerPage`**|number|10|Number of rows allowed per page
 |**`rowsPerPageOptions`**|array|[10,15,100]|Options to provide in pagination for number of rows a user can select
 |**`rowHover`**|boolean|true|Enable/disable hover style over rows

--- a/examples/array-value-columns/index.js
+++ b/examples/array-value-columns/index.js
@@ -94,7 +94,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
     };
 
     return (

--- a/examples/column-filters/index.js
+++ b/examples/column-filters/index.js
@@ -94,7 +94,7 @@ class Example extends React.Component {
       },
       selectableRows: 'multiple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       page: 1,
     };

--- a/examples/column-options-update/index.js
+++ b/examples/column-options-update/index.js
@@ -125,7 +125,7 @@ class Example extends React.Component {
       },
       selectableRows: 'multiple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       page: 1,
     };

--- a/examples/component/index.js
+++ b/examples/component/index.js
@@ -126,7 +126,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight'
+      responsive: 'standard'
     };
 
     return (

--- a/examples/csv-export/index.js
+++ b/examples/csv-export/index.js
@@ -69,7 +69,7 @@ class Example extends React.Component {
       filter: true,
       selectableRows: 'multiple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       downloadOptions: {
           filename: 'excel-format.csv',

--- a/examples/custom-action-columns/index.js
+++ b/examples/custom-action-columns/index.js
@@ -167,7 +167,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       page: 2,
       onColumnSortChange: (changedColumn, direction) => console.log('changedColumn: ', changedColumn, 'direction: ', direction),
       onChangeRowsPerPage: numberOfRows => console.log('numberOfRows: ', numberOfRows),

--- a/examples/customize-columns/index.js
+++ b/examples/customize-columns/index.js
@@ -85,7 +85,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
     };
 
     return (

--- a/examples/customize-filter/index.js
+++ b/examples/customize-filter/index.js
@@ -229,7 +229,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'multiselect',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
     };
 
     return (

--- a/examples/customize-footer/index.js
+++ b/examples/customize-footer/index.js
@@ -44,7 +44,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => {
         return (  

--- a/examples/customize-rows/index.js
+++ b/examples/customize-rows/index.js
@@ -71,7 +71,7 @@ function Example() {
       ]}
       options={{
         selectableRows: "none",
-        responsive: "scrollMaxHeight",
+        responsive: "standard",
         customRowRender: data => {
           const [ name, cardNumber, cvc, expiry ] = data;
           

--- a/examples/customize-search-render/index.js
+++ b/examples/customize-search-render/index.js
@@ -46,7 +46,7 @@ class Example extends React.Component {
       filter: true,
       selectableRows: 'mulitple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       customSearchRender: (searchText, handleSearch, hideSearch, options) => {
         return (

--- a/examples/customize-search/index.js
+++ b/examples/customize-search/index.js
@@ -80,7 +80,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       page: 0,
       searchText: this.state.searchText,
       searchProps: {

--- a/examples/customize-sorting/index.js
+++ b/examples/customize-sorting/index.js
@@ -19,7 +19,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       customSort: (data, colIndex, order) => {
         return data.sort((a, b) => {
           return (a.data[colIndex].length < b.data[colIndex].length ? -1: 1 ) * (order === 'desc' ? 1 : -1);

--- a/examples/customize-styling/index.js
+++ b/examples/customize-styling/index.js
@@ -24,7 +24,7 @@ class Example extends React.Component {
     super(props);
     this.state = {
       denseTable: false,
-      stacked: true
+      vertical: true
     };
   }
 
@@ -54,7 +54,7 @@ class Example extends React.Component {
 
   toggleResponsive = (event) => {
     this.setState({
-      stacked: event.target.checked ? true : false
+      vertical: event.target.checked ? true : false
     });
   }
 
@@ -149,7 +149,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: this.state.stacked ? 'stacked' : 'scrollMaxHeight',
+      responsive: this.state.vertical ? 'vertical' : 'standard',
       fixedHeader: false,
       fixedSelectColumn: false,
       rowHover: false,
@@ -191,13 +191,13 @@ class Example extends React.Component {
           <FormControlLabel
             control={
               <Switch
-                checked={this.state.stacked}
+                checked={this.state.vertical}
                 onChange={this.toggleResponsive}
-                value="stacked"
+                value="vertical"
                 color="primary"
               />
             }
-            label="Stacked Table"
+            label="Responsive Vertical Table"
           />
         </FormGroup>
         <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />

--- a/examples/customize-toolbar/index.js
+++ b/examples/customize-toolbar/index.js
@@ -46,7 +46,7 @@ class Example extends React.Component {
       filter: true,
       selectableRows: 'multiple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       customToolbar: () => {
         return (

--- a/examples/customize-toolbarselect/index.js
+++ b/examples/customize-toolbarselect/index.js
@@ -44,7 +44,7 @@ class Example extends React.Component {
       filter: true,
       selectableRows: 'multiple',
       filterType: "dropdown",
-      responsive: "stacked",
+      responsive: "vertical",
       rowsPerPage: 10,
       customToolbarSelect: (selectedRows, displayData, setSelectedRows) => (
         <CustomToolbarSelect selectedRows={selectedRows} displayData={displayData} setSelectedRows={setSelectedRows} />

--- a/examples/data-as-objects/index.js
+++ b/examples/data-as-objects/index.js
@@ -77,7 +77,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       enableNestedDataAccess: '.', // allows nested data separated by "." (see column names and the data structure above)
     };
 

--- a/examples/expandable-rows/index.js
+++ b/examples/expandable-rows/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+ import React from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src/";
 import TableRow from "@material-ui/core/TableRow";
@@ -80,7 +80,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       expandableRows: true,
       expandableRowsHeader: true,
       expandableRowsOnClick: true,

--- a/examples/fixed-header/index.js
+++ b/examples/fixed-header/index.js
@@ -102,7 +102,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       fixedHeader: true,
       fixedSelectColumn: true
     };

--- a/examples/hide-columns-print/index.js
+++ b/examples/hide-columns-print/index.js
@@ -81,7 +81,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
     };
 
     return (

--- a/examples/large-data-set/index.js
+++ b/examples/large-data-set/index.js
@@ -121,7 +121,7 @@ class Example extends React.Component {
       rowsPerPageOptions: [10, 100, 250, 500, 1000],
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       customSearchRender: debounceSearchRender(500),
     };
 

--- a/examples/large-data-set/index.js
+++ b/examples/large-data-set/index.js
@@ -61,8 +61,8 @@ class Example extends React.Component {
         options: {
           filter: true,
           customBodyRender: (val, tableMeta) => {
-            console.log(val);
-            console.dir(tableMeta);
+            //console.log(val);
+            //console.dir(tableMeta);
             return val;
           }
         }
@@ -121,7 +121,8 @@ class Example extends React.Component {
       rowsPerPageOptions: [10, 100, 250, 500, 1000],
       filter: true,
       filterType: 'dropdown',
-      responsive: 'standard',
+      responsive: 'vertical',
+      tableBodyHeight:'500px',
       customSearchRender: debounceSearchRender(500),
     };
 

--- a/examples/on-download/index.js
+++ b/examples/on-download/index.js
@@ -103,7 +103,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       onDownload: (buildHead, buildBody, columns, data) =>
         buildHead(headerNames) +
         buildBody(

--- a/examples/on-table-init/index.js
+++ b/examples/on-table-init/index.js
@@ -67,7 +67,7 @@ class Example extends React.Component {
     filter: true,
     selectableRows: 'multiple',
     filterType: 'dropdown',
-    responsive: 'scrollMaxHeight',
+    responsive: 'standard',
     rowsPerPage: 10,
     download: false, // hide csv download option
     onTableInit: this.handleTableInit,

--- a/examples/selectable-rows/index.js
+++ b/examples/selectable-rows/index.js
@@ -70,7 +70,7 @@ class Example extends React.Component {
       selectableRowsOnClick: true,
       selectableRowsHideCheckboxes: this.state.selectableRowsHideCheckboxes,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       rowsSelected: this.state.rowsSelected,
       onRowsSelect: (rowsSelected, allRows) => {

--- a/examples/serverside-filters/index.js
+++ b/examples/serverside-filters/index.js
@@ -156,7 +156,7 @@ class Example extends React.Component {
       filter: true,
       serverSideFilterList: this.state.serverSideFilterList,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       serverSide: true,
       onFilterDialogOpen: () => {
         console.log('filter dialog opened');

--- a/examples/serverside-options/index.js
+++ b/examples/serverside-options/index.js
@@ -45,7 +45,7 @@ class Example extends React.Component {
       filter: true,
       selectableRows: 'multiple',
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 10,
       page: 1,
       rowsSelected: [2, 5],

--- a/examples/serverside-pagination/index.js
+++ b/examples/serverside-pagination/index.js
@@ -73,7 +73,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       serverSide: true,
       count: count,
       page: page,

--- a/examples/serverside-sorting/index.js
+++ b/examples/serverside-sorting/index.js
@@ -178,7 +178,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'scrollMaxHeight',
+      responsive: 'standard',
       serverSide: true,
       count: count,
       page: page,

--- a/examples/simple-no-toolbar/index.js
+++ b/examples/simple-no-toolbar/index.js
@@ -21,7 +21,7 @@ class Example extends React.Component {
       download: false,
       viewColumns: false,
       customToolbar: null,
-      responsive: 'stacked'
+      responsive: 'vertical'
     };
 
     return (

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,44 +1,98 @@
-import React from "react";
+import React, {useState} from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src/";
 
-class Example extends React.Component {
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
 
-  state = {
-    counter: 0,
-    data: [
-        ["Gabby George", "Business Analyst", "Minneapolis"],
-        ["Aiden Lloyd", "Business Consultant", "Dallas"],
-        ["Jaden Collins", "Attorney", "Santa Ana"],
-        ["Franky Rees", "Business Analyst", "St. Petersburg"],
-        ["Aaren Rose", null, "Toledo"]
-      ]
-  }
+function Example() {
 
-  rerender = () => {
-    this.setState((prevState, props) => ({
-      counter: prevState.counter + 1
-    })); 
-  }
+  const [responsive, setResponsive] = useState("vertical");
+  const [tableBodyHeight, setTableBodyHeight] = useState("400px");
+  const [tableBodyMaxHeight, setTableBodyMaxHeight] = useState("");
 
-  render() {
+  const columns = ["Name", "Title", "Location"];
 
-    const columns = ["Name", "Title", "Location"];
+  const options = {
+    filter: true,
+    filterType: 'dropdown',
+    responsive,
+    tableBodyHeight,
+    tableBodyMaxHeight
+  };
 
-    const options = {
-      filter: true,
-      filterType: 'dropdown',
-      responsive: 'stacked',
-    };
+  const data = [
+    ["Gabby George", "Business Analyst", "Minneapolis"],
+    ["Aiden Lloyd", "Business Consultant for an International Company and CEO of Tony's Burger Palace", "Dallas"],
+    ["Jaden Collins", "Attorney", "Santa Ana"],
+    ["Franky Rees", "Business Analyst", "St. Petersburg"],
+    ["Aaren Rose", null, "Toledo"],
+    ["Johnny Jones", "Business Analyst", "St. Petersburg"],
+    ["Jimmy Johns", "Business Analyst", "Baltimore"],
+    ["Jack Jackson", "Business Analyst", "El Paso"],
+    ["Joe Jones", "Computer Programmer", "El Paso"],
+    ["Jacky Jackson", "Business Consultant", "Baltimore"],
+    ["Jo Jo", "Software Developer", "Washington DC"],
+    ["Donna Marie", "Business Manager", "Annapolis"],
 
-    return (
-      <React.Fragment>
-        <button onClick={this.rerender}>Re-render - {this.state.counter}</button>
-        <MUIDataTable title={"ACME Employee list"} data={this.state.data} columns={columns} options={options} />
-      </React.Fragment>
-    );
+  ];
 
-  }
+  return (
+    <React.Fragment>
+      <FormControl>
+        <InputLabel id="demo-simple-select-label">Responsive Option</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={responsive}
+          style={{width:'200px', marginBottom:'10px', marginRight:10}}
+          onChange={(e) => setResponsive(e.target.value)}
+        >
+          <MenuItem value={"vertical"}>vertical</MenuItem>
+          <MenuItem value={"standard"}>standard</MenuItem>
+          <MenuItem value={"simple"}>simple</MenuItem>
+
+          <MenuItem value={"scroll"}>scroll (deprecated)</MenuItem>
+          <MenuItem value={"scrollMaxHeight"}>scrollMaxHeight (deprecated)</MenuItem>
+          <MenuItem value={"stacked"}>stacked (deprecated)</MenuItem>
+        </Select>
+      </FormControl>
+      <FormControl>
+        <InputLabel id="demo-simple-select-label">Table Body Height</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={tableBodyHeight}
+          style={{width:'200px', marginBottom:'10px', marginRight:10}}
+          onChange={(e) => setTableBodyHeight(e.target.value)}
+        >
+          <MenuItem value={""}>[blank]</MenuItem>
+          <MenuItem value={"400px"}>400px</MenuItem>
+          <MenuItem value={"800px"}>800px</MenuItem>
+          <MenuItem value={"100%"}>100%</MenuItem>
+        </Select>
+      </FormControl>
+      <FormControl>
+        <InputLabel id="demo-simple-select-label">Max Table Body Height</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={tableBodyMaxHeight}
+          style={{width:'200px', marginBottom:'10px'}}
+          onChange={(e) => setTableBodyMaxHeight(e.target.value)}
+        >
+          <MenuItem value={""}>[blank]</MenuItem>
+          <MenuItem value={"400px"}>400px</MenuItem>
+          <MenuItem value={"800px"}>800px</MenuItem>
+          <MenuItem value={"100%"}>100%</MenuItem>
+        </Select>
+      </FormControl>
+      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+    </React.Fragment>
+  );
 }
 
 export default Example;

--- a/examples/text-localization/index.js
+++ b/examples/text-localization/index.js
@@ -44,7 +44,7 @@ class Example extends React.Component {
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       textLabels: {
         body: {
           noMatch: "Sorry we could not find any records!",

--- a/examples/themes/index.js
+++ b/examples/themes/index.js
@@ -76,7 +76,7 @@ class Example extends React.Component {
             filter: true,
             selectableRows: 'multiple',
             filterType: 'dropdown',
-            responsive: 'stacked',
+            responsive: 'vertical',
             rowsPerPage: 10,
             page: 1,
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "2.15.0",
+  "version": "3.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -30,19 +30,16 @@ const defaultTableStyles = theme => ({
     outline: 'none',
   },
   responsiveBase: {
-    overflowX: 'auto',
     overflow: 'auto',
   },
 
   // deprecated, but continuing support through v3.x
   responsiveScroll: {
-    overflowX: 'auto',
     overflow: 'auto',
     height: '100%',
   },
   // deprecated, but continuing support through v3.x
   responsiveScrollMaxHeight: {
-    overflowX: 'auto',
     overflow: 'auto',
     height: '100%',
   },
@@ -52,10 +49,8 @@ const defaultTableStyles = theme => ({
   },
   // deprecated, but continuing support through v3.x
   responsiveStacked: {
-    overflowX: 'auto',
     overflow: 'auto',
     [theme.breakpoints.down('sm')]: {
-      overflowX: 'hidden',
       overflow: 'hidden',
     },
   },
@@ -379,12 +374,24 @@ class MUIDataTable extends React.Component {
       this.options.selectableRows = this.options.selectableRows ? 'multiple' : 'none';
     }
     if (!['standard', 'vertical', 'simple'].includes(this.options.responsive)) {
-      if ( ['scrollMaxHeight', 'scrollFullHeight', 'stacked', 'stackedFullWidth', 'scrollFullHeightFullWidth', 'scroll'].includes(this.options.responsive) ) {
+      if (
+        [
+          'scrollMaxHeight',
+          'scrollFullHeight',
+          'stacked',
+          'stackedFullWidth',
+          'scrollFullHeightFullWidth',
+          'scroll',
+        ].includes(this.options.responsive)
+      ) {
         warnDeprecated(
           this.options.responsive + ' has been deprecated. Please use string option: standard | vertical | simple',
         );
       } else {
-        warnInfo(this.options.responsive + ' is not recognized as a valid input for responsive option. Please use string option: standard | vertical | simple');
+        warnInfo(
+          this.options.responsive +
+            ' is not recognized as a valid input for responsive option. Please use string option: standard | vertical | simple',
+        );
       }
     }
     if (this.options.fixedHeaderOptions) {
@@ -1506,7 +1513,7 @@ class MUIDataTable extends React.Component {
 
     switch (responsiveOption) {
       // deprecated
-      case 'scroll': 
+      case 'scroll':
         responsiveClass = classes.responsiveScroll;
         maxHeight = '499px';
         break;
@@ -1550,7 +1557,7 @@ class MUIDataTable extends React.Component {
     if (this.options.tableBodyHeight) {
       tableHeightVal.height = this.options.tableBodyHeight;
     }
-    
+
     let tableProps = this.options.setTableProps ? this.options.setTableProps() : {};
     let tableClassNames = classnames(classes.tableRoot, tableProps.className);
     delete tableProps.className; // remove className from props to avoid the className being applied twice

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -378,10 +378,14 @@ class MUIDataTable extends React.Component {
       );
       this.options.selectableRows = this.options.selectableRows ? 'multiple' : 'none';
     }
-    if (['standard', 'vertical', 'simple'].indexOf(this.options.responsive) === -1) {
-      warnDeprecated(
-        'Invalid option value for responsive. The field has been refactored for v3. Please use string option: standard | vertical | simple',
-      );
+    if (!['standard', 'vertical', 'simple'].includes(this.options.responsive)) {
+      if ( ['scrollMaxHeight', 'scrollFullHeight', 'stacked', 'stackedFullWidth', 'scrollFullHeightFullWidth', 'scroll'].includes(this.options.responsive) ) {
+        warnDeprecated(
+          this.options.responsive + ' has been deprecated. Please use string option: standard | vertical | simple',
+        );
+      } else {
+        warnInfo(this.options.responsive + ' is not recognized as a valid input for responsive option. Please use string option: standard | vertical | simple');
+      }
     }
     if (this.options.fixedHeaderOptions) {
       warnDeprecated('fixedHeaderOptions has been deprecated in favor of fixedHeader and fixedSelectColumn.');
@@ -1500,49 +1504,50 @@ class MUIDataTable extends React.Component {
     let maxHeight = this.options.tableBodyMaxHeight;
     let responsiveClass;
 
-    if (this.options.tableBodyMaxHeight && this.options.tableBodyHeight){
-      warnInfo('Both tableBodyMaxHeight and tableBodyHeight, tableBodyMaxHeight will be used.');
-    }
-
     switch (responsiveOption) {
-      case 'standard':
-      case 'simple':
-      case 'vertical':
-        responsiveClass = classes.responsiveBase;
-        break;
-
-      // All of the below cases are DEPRECATED, but will be supported through v3.x
-      case 'scroll':
+      // deprecated
+      case 'scroll': 
         responsiveClass = classes.responsiveScroll;
         maxHeight = '499px';
         break;
+      // deprecated
       case 'scrollMaxHeight':
         responsiveClass = classes.responsiveScrollMaxHeight;
         maxHeight = '499px';
         break;
+      // deprecated
       case 'scrollFullHeight':
         responsiveClass = classes.responsiveScrollFullHeight;
         maxHeight = 'none';
         break;
+      // deprecated
       case 'scrollFullHeightFullWidth':
         responsiveClass = classes.responsiveScrollFullHeight;
         paperClasses = `${classes.paperResponsiveScrollFullHeightFullWidth} ${className}`;
         break;
+      // deprecated
       case 'stacked':
         responsiveClass = classes.responsiveStacked;
         maxHeight = 'none';
         break;
+      // deprecated
       case 'stackedFullWidth':
         responsiveClass = classes.responsiveStackedFullWidth;
         paperClasses = `${classes.paperResponsiveScrollFullHeightFullWidth} ${className}`;
         maxHeight = 'none';
         break;
+
+      default:
+        responsiveClass = classes.responsiveBase;
+        break;
     }
 
     var tableHeightVal = {};
     if (maxHeight) {
-      tableHeightVal.maxHeight = tableHeightVal;
-    } else {
+      console.log('max!');
+      tableHeightVal.maxHeight = maxHeight;
+    }
+    if (this.options.tableBodyHeight) {
       tableHeightVal.height = this.options.tableBodyHeight;
     }
     

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -8,13 +8,28 @@ import TableSelectCell from './TableSelectCell';
 import { withStyles } from '@material-ui/core/styles';
 import cloneDeep from 'lodash.clonedeep';
 import { getPageValue, warnDeprecated } from '../utils';
+import classNames from 'classnames';
 
-const defaultBodyStyles = {
+const defaultBodyStyles = theme => ({
   root: {},
   emptyTitle: {
     textAlign: 'center',
   },
-};
+  lastStackedCell: {
+    [theme.breakpoints.down('sm')]: {
+      '& td:last-child': {
+        borderBottom: 'none'
+      }
+    }
+  },
+  lastSimpleCell: {
+    [theme.breakpoints.down('xs')]: {
+      '& td:last-child': {
+        borderBottom: 'none'
+      }
+    }
+  },
+});
 
 class TableBody extends React.Component {
   static propTypes = {
@@ -230,6 +245,10 @@ class TableBody extends React.Component {
                   rowSelected={isRowSelected}
                   isRowSelectable={isRowSelectable}
                   onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
+                  className={classNames({
+                    [classes.lastStackedCell]: options.responsive === 'vertical' || options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+                    [classes.lastSimpleCell]: options.responsive === 'simple',
+                  })}
                   data-testid={'MUIDataTableBodyRow-' + dataIndex}
                   id={'MUIDataTableBodyRow-' + dataIndex}>
                   <TableSelectCell

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -236,11 +236,12 @@ class TableBody extends React.Component {
 
             let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;
             let isRowSelectable = this.isRowSelectable(dataIndex);
+            let bodyClasses = (options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) : {});
 
             return (
               <React.Fragment key={rowIndex}>
                 <TableBodyRow
-                  {...(options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) : {})}
+                  {...bodyClasses}
                   options={options}
                   rowSelected={isRowSelected}
                   isRowSelectable={isRowSelectable}
@@ -248,6 +249,7 @@ class TableBody extends React.Component {
                   className={classNames({
                     [classes.lastStackedCell]: options.responsive === 'vertical' || options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
                     [classes.lastSimpleCell]: options.responsive === 'simple',
+                    [bodyClasses.className]: bodyClasses.className
                   })}
                   data-testid={'MUIDataTableBodyRow-' + dataIndex}
                   id={'MUIDataTableBodyRow-' + dataIndex}>

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -18,16 +18,16 @@ const defaultBodyStyles = theme => ({
   lastStackedCell: {
     [theme.breakpoints.down('sm')]: {
       '& td:last-child': {
-        borderBottom: 'none'
-      }
-    }
+        borderBottom: 'none',
+      },
+    },
   },
   lastSimpleCell: {
     [theme.breakpoints.down('xs')]: {
       '& td:last-child': {
-        borderBottom: 'none'
-      }
-    }
+        borderBottom: 'none',
+      },
+    },
   },
 });
 
@@ -236,7 +236,7 @@ class TableBody extends React.Component {
 
             let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;
             let isRowSelectable = this.isRowSelectable(dataIndex);
-            let bodyClasses = (options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) : {});
+            let bodyClasses = options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) : {};
 
             return (
               <React.Fragment key={rowIndex}>
@@ -247,9 +247,12 @@ class TableBody extends React.Component {
                   isRowSelectable={isRowSelectable}
                   onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
                   className={classNames({
-                    [classes.lastStackedCell]: options.responsive === 'vertical' || options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+                    [classes.lastStackedCell]:
+                      options.responsive === 'vertical' ||
+                      options.responsive === 'stacked' ||
+                      options.responsive === 'stackedFullWidth',
                     [classes.lastSimpleCell]: options.responsive === 'simple',
-                    [bodyClasses.className]: bodyClasses.className
+                    [bodyClasses.className]: bodyClasses.className,
                   })}
                   data-testid={'MUIDataTableBodyRow-' + dataIndex}
                   id={'MUIDataTableBodyRow-' + dataIndex}>

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -2,26 +2,53 @@ import React from 'react';
 import classNames from 'classnames';
 import TableCell from '@material-ui/core/TableCell';
 import { withStyles } from '@material-ui/core/styles';
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
+
+const ConditionalWrapper = ({ condition, wrapper, children }) => (condition ? wrapper(children) : children);
 
 const defaultBodyCellStyles = theme => ({
   root: {},
   cellHide: {
     display: 'none',
   },
+  simpleHeader: {
+    [theme.breakpoints.down('xs')]: {
+      display: 'inline-block',
+      fontWeight: 'bold',
+      width: '100%',
+    },
+  },
+  simpleCell: {
+    [theme.breakpoints.down('xs')]: {
+      display: 'inline-block',
+      width: '100%',
+    },
+  },
+  stackedHeader: {
+    verticalAlign:'top',
+  },
   stackedCommon: {
     [theme.breakpoints.down('sm')]: {
       display: 'inline-block',
       fontSize: '16px',
-      height: '24px',
-      whiteSpace: 'nowrap',
-      width: 'calc(50% - 80px)',
-      whiteSpace: 'nowrap',
+      height: 'auto',
+      width: 'calc(50%)',
+      boxSizing: 'border-box',
       '&:last-child': {
         borderBottom: 'none',
       },
       '&:nth-last-child(2)': {
         borderBottom: 'none',
       },
+    },
+  },
+  stackedParent: {
+    [theme.breakpoints.down('sm')]: {
+      display: 'inline-block',
+      fontSize: '16px',
+      height: 'auto',
+      width: 'calc(100%)',
+      boxSizing: 'border-box',
     },
   },
   cellStackedSmall: {
@@ -32,6 +59,11 @@ const defaultBodyCellStyles = theme => ({
   responsiveStackedSmall: {
     [theme.breakpoints.down('sm')]: {
       width: '50%',
+    },
+  },
+  responsiveStackedSmallParent: {
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
     },
   },
 });
@@ -55,47 +87,92 @@ class TableBodyCell extends React.Component {
       rowIndex,
       className,
       print,
+      tmp,
       ...otherProps
     } = this.props;
 
-    return [
-      <TableCell
+    let cells = [
+      <div
         key={1}
         className={classNames(
           {
+            lastColumn: colIndex === 2,
             [classes.root]: true,
             [classes.cellHide]: true,
-            [classes.stackedCommon]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+            [classes.stackedHeader]: true,
+            [classes.stackedCommon]:
+              options.responsive === 'vertical' ||
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth',
             [classes.cellStackedSmall]:
               options.responsive === 'stacked' ||
               (options.responsive === 'stackedFullWidth' &&
                 (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+            [classes.simpleHeader]: options.responsive === 'simple',
             'datatables-noprint': !print,
           },
           className,
         )}>
         {columnHeader}
-      </TableCell>,
-      <TableCell
+      </div>,
+      <div
         key={2}
-        onClick={this.handleClick}
         className={classNames(
           {
             [classes.root]: true,
-            [classes.stackedCommon]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+            [classes.stackedCommon]:
+              options.responsive === 'vertical' ||
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth',
             [classes.responsiveStackedSmall]:
               options.responsive === 'stacked' ||
               (options.responsive === 'stackedFullWidth' &&
                 (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+            [classes.simpleCell]: options.responsive === 'simple',
             'datatables-noprint': !print,
           },
           className,
         )}
         {...otherProps}>
         {children}
-      </TableCell>,
+      </div>,
     ];
+
+    var innerCells;
+    if (
+      ['standard', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth'].indexOf(options.responsive) !==
+      -1
+    ) {
+      innerCells = cells.slice(1, 2);
+    } else {
+      innerCells = cells;
+    }
+
+    return (
+      <TableCell
+        onClick={this.handleClick}
+        className={classNames(
+        {
+          [classes.root]: true,
+          [classes.stackedParent]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            options.responsive === 'stackedFullWidth',
+          [classes.responsiveStackedSmallParent]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            (options.responsive === 'stackedFullWidth' &&
+              (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+          [classes.simpleCell]: options.responsive === 'simple',
+          'datatables-noprint': !print,
+        },
+        className,
+      )}
+      {...otherProps}>
+      {innerCells}
+      </TableCell>
+    );
   }
 }
 
-export default withStyles(defaultBodyCellStyles, { name: 'MUIDataTableBodyCell' })(TableBodyCell);
+export default withWidth()(withStyles(defaultBodyCellStyles, { name: 'MUIDataTableBodyCell' })(TableBodyCell));

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -13,12 +13,14 @@ const defaultBodyCellStyles = theme => ({
       display: 'inline-block',
       fontWeight: 'bold',
       width: '100%',
+      boxSizing: 'border-box',
     },
   },
   simpleCell: {
     [theme.breakpoints.down('xs')]: {
       display: 'inline-block',
       width: '100%',
+      boxSizing: 'border-box',
     },
   },
   stackedHeader: {
@@ -51,16 +53,19 @@ const defaultBodyCellStyles = theme => ({
   cellStackedSmall: {
     [theme.breakpoints.down('sm')]: {
       width: '50%',
+      boxSizing: 'border-box',
     },
   },
   responsiveStackedSmall: {
     [theme.breakpoints.down('sm')]: {
       width: '50%',
+      boxSizing: 'border-box',
     },
   },
   responsiveStackedSmallParent: {
     [theme.breakpoints.down('sm')]: {
       width: '100%',
+      boxSizing: 'border-box',
     },
   },
 });

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -2,9 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import TableCell from '@material-ui/core/TableCell';
 import { withStyles } from '@material-ui/core/styles';
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
-
-const ConditionalWrapper = ({ condition, wrapper, children }) => (condition ? wrapper(children) : children);
 
 const defaultBodyCellStyles = theme => ({
   root: {},
@@ -87,7 +84,6 @@ class TableBodyCell extends React.Component {
       rowIndex,
       className,
       print,
-      tmp,
       ...otherProps
     } = this.props;
 
@@ -175,4 +171,4 @@ class TableBodyCell extends React.Component {
   }
 }
 
-export default withWidth()(withStyles(defaultBodyCellStyles, { name: 'MUIDataTableBodyCell' })(TableBodyCell));
+export default withStyles(defaultBodyCellStyles, { name: 'MUIDataTableBodyCell' })(TableBodyCell);

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -24,7 +24,7 @@ const defaultBodyCellStyles = theme => ({
     },
   },
   stackedHeader: {
-    verticalAlign:'top',
+    verticalAlign: 'top',
   },
   stackedCommon: {
     [theme.breakpoints.down('sm')]: {
@@ -153,24 +153,24 @@ class TableBodyCell extends React.Component {
       <TableCell
         onClick={this.handleClick}
         className={classNames(
-        {
-          [classes.root]: true,
-          [classes.stackedParent]:
-            options.responsive === 'vertical' ||
-            options.responsive === 'stacked' ||
-            options.responsive === 'stackedFullWidth',
-          [classes.responsiveStackedSmallParent]:
-            options.responsive === 'vertical' ||
-            options.responsive === 'stacked' ||
-            (options.responsive === 'stackedFullWidth' &&
-              (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
-          [classes.simpleCell]: options.responsive === 'simple',
-          'datatables-noprint': !print,
-        },
-        className,
-      )}
-      {...otherProps}>
-      {innerCells}
+          {
+            [classes.root]: true,
+            [classes.stackedParent]:
+              options.responsive === 'vertical' ||
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth',
+            [classes.responsiveStackedSmallParent]:
+              options.responsive === 'vertical' ||
+              options.responsive === 'stacked' ||
+              (options.responsive === 'stackedFullWidth' &&
+                (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+            [classes.simpleCell]: options.responsive === 'simple',
+            'datatables-noprint': !print,
+          },
+          className,
+        )}
+        {...otherProps}>
+        {innerCells}
       </TableCell>
     );
   }

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import classNames from 'classnames';
 import TableCell from '@material-ui/core/TableCell';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const defaultBodyCellStyles = theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {},
   cellHide: {
     display: 'none',
@@ -68,112 +68,114 @@ const defaultBodyCellStyles = theme => ({
       boxSizing: 'border-box',
     },
   },
-});
+}), { name: 'MUIDataTableBodyCell' });
 
-class TableBodyCell extends React.Component {
-  handleClick = event => {
-    const { colIndex, options, children, dataIndex, rowIndex } = this.props;
-    if (options.onCellClick) {
-      options.onCellClick(children, { colIndex, rowIndex, dataIndex, event });
-    }
-  };
+function TableBodyCell(props) {
+  const classes = useStyles();
+  const {
+    children,
+    colIndex,
+    columnHeader,
+    options,
+    dataIndex,
+    rowIndex,
+    className,
+    print,
+    ...otherProps
+  } = props;
+  const onCellClick = options.onCellClick;
 
-  render() {
-    const {
-      children,
-      classes,
-      colIndex,
-      columnHeader,
-      options,
-      dataIndex,
-      rowIndex,
-      className,
-      print,
-      ...otherProps
-    } = this.props;
+  const handleClick = useCallback(event => {
+    onCellClick(children, { colIndex, rowIndex, dataIndex, event });
+  }, [onCellClick, children, colIndex, rowIndex, dataIndex]);
 
-    let cells = [
-      <div
-        key={1}
-        className={classNames(
-          {
-            lastColumn: colIndex === 2,
-            [classes.root]: true,
-            [classes.cellHide]: true,
-            [classes.stackedHeader]: true,
-            [classes.stackedCommon]:
-              options.responsive === 'vertical' ||
-              options.responsive === 'stacked' ||
-              options.responsive === 'stackedFullWidth',
-            [classes.cellStackedSmall]:
-              options.responsive === 'stacked' ||
-              (options.responsive === 'stackedFullWidth' &&
-                (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
-            [classes.simpleHeader]: options.responsive === 'simple',
-            'datatables-noprint': !print,
-          },
-          className,
-        )}>
-        {columnHeader}
-      </div>,
-      <div
-        key={2}
-        className={classNames(
-          {
-            [classes.root]: true,
-            [classes.stackedCommon]:
-              options.responsive === 'vertical' ||
-              options.responsive === 'stacked' ||
-              options.responsive === 'stackedFullWidth',
-            [classes.responsiveStackedSmall]:
-              options.responsive === 'stacked' ||
-              (options.responsive === 'stackedFullWidth' &&
-                (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
-            [classes.simpleCell]: options.responsive === 'simple',
-            'datatables-noprint': !print,
-          },
-          className,
-        )}
-        {...otherProps}>
-        {children}
-      </div>,
-    ];
-
-    var innerCells;
-    if (
-      ['standard', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth'].indexOf(options.responsive) !==
-      -1
-    ) {
-      innerCells = cells.slice(1, 2);
-    } else {
-      innerCells = cells;
-    }
-
-    return (
-      <TableCell
-        onClick={this.handleClick}
-        className={classNames(
-          {
-            [classes.root]: true,
-            [classes.stackedParent]:
-              options.responsive === 'vertical' ||
-              options.responsive === 'stacked' ||
-              options.responsive === 'stackedFullWidth',
-            [classes.responsiveStackedSmallParent]:
-              options.responsive === 'vertical' ||
-              options.responsive === 'stacked' ||
-              (options.responsive === 'stackedFullWidth' &&
-                (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
-            [classes.simpleCell]: options.responsive === 'simple',
-            'datatables-noprint': !print,
-          },
-          className,
-        )}
-        {...otherProps}>
-        {innerCells}
-      </TableCell>
-    );
+  // Event listeners. Avoid attaching them if they're not necessary.
+  let methods = {};
+  if (onCellClick) {
+    methods.onClick = handleClick;
   }
+
+  let cells = [
+    <div
+      key={1}
+      className={classNames(
+        {
+          lastColumn: colIndex === 2,
+          [classes.root]: true,
+          [classes.cellHide]: true,
+          [classes.stackedHeader]: true,
+          [classes.stackedCommon]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            options.responsive === 'stackedFullWidth',
+          [classes.cellStackedSmall]:
+            options.responsive === 'stacked' ||
+            (options.responsive === 'stackedFullWidth' &&
+              (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+          [classes.simpleHeader]: options.responsive === 'simple',
+          'datatables-noprint': !print,
+        },
+        className,
+      )}>
+      {columnHeader}
+    </div>,
+    <div
+      key={2}
+      className={classNames(
+        {
+          [classes.root]: true,
+          [classes.stackedCommon]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            options.responsive === 'stackedFullWidth',
+          [classes.responsiveStackedSmall]:
+            options.responsive === 'stacked' ||
+            (options.responsive === 'stackedFullWidth' &&
+              (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+          [classes.simpleCell]: options.responsive === 'simple',
+          'datatables-noprint': !print,
+        },
+        className,
+      )}
+      {...otherProps}>
+      {children}
+    </div>,
+  ];
+
+  var innerCells;
+  if (
+    ['standard', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth'].indexOf(options.responsive) !==
+    -1
+  ) {
+    innerCells = cells.slice(1, 2);
+  } else {
+    innerCells = cells;
+  }
+
+  return (
+    <TableCell
+      {...methods}
+      className={classNames(
+        {
+          [classes.root]: true,
+          [classes.stackedParent]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            options.responsive === 'stackedFullWidth',
+          [classes.responsiveStackedSmallParent]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            (options.responsive === 'stackedFullWidth' &&
+              (options.setTableProps().padding === 'none' || options.setTableProps().size === 'small')),
+          [classes.simpleCell]: options.responsive === 'simple',
+          'datatables-noprint': !print,
+        },
+        className,
+      )}
+      {...otherProps}>
+      {innerCells}
+    </TableCell>
+  );
 }
 
-export default withStyles(defaultBodyCellStyles, { name: 'MUIDataTableBodyCell' })(TableBodyCell);
+export default TableBodyCell;

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -19,12 +19,18 @@ const defaultBodyRowStyles = theme => ({
   hoverCursor: { cursor: 'pointer' },
   responsiveStacked: {
     [theme.breakpoints.down('sm')]: {
-      border: 'solid 2px rgba(0, 0, 0, 0.15)',
+      borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
+      borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
+      padding:0,
+      margin:0,
     },
   },
   responsiveSimple: {
     [theme.breakpoints.down('xs')]: {
-      border: 'solid 2px rgba(0, 0, 0, 0.15)',
+      borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
+      borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
+      padding:0,
+      margin:0,
     },
   },
 });

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -8,28 +8,22 @@ const defaultBodyRowStyles = theme => ({
   root: {
     // material v4
     '&.Mui-selected': {
-      '& td': {
-        backgroundColor: theme.palette.action.selected,
-      },
+      backgroundColor: theme.palette.action.selected,
     },
 
     // material v3 workaround
     '&.mui-row-selected': {
-      '& td': {
-        backgroundColor: theme.palette.action.selected,
-      },
-    },
-  },
-  hover: {
-    '&:hover': {
-      '& td': {
-        backgroundColor: theme.palette.action.hover,
-      },
+      backgroundColor: theme.palette.action.selected,
     },
   },
   hoverCursor: { cursor: 'pointer' },
   responsiveStacked: {
     [theme.breakpoints.down('sm')]: {
+      border: 'solid 2px rgba(0, 0, 0, 0.15)',
+    },
+  },
+  responsiveSimple: {
+    [theme.breakpoints.down('xs')]: {
       border: 'solid 2px rgba(0, 0, 0, 0.15)',
     },
   },
@@ -59,7 +53,11 @@ class TableBodyRow extends React.Component {
             [classes.root]: true,
             [classes.hover]: options.rowHover,
             [classes.hoverCursor]: (options.selectableRowsOnClick && isRowSelectable) || options.expandableRowsOnClick,
-            [classes.responsiveStacked]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+            [classes.responsiveSimple]: options.responsive === 'simple',
+            [classes.responsiveStacked]:
+              options.responsive === 'vertical' ||
+              options.responsive === 'stacked' ||
+              options.responsive === 'stackedFullWidth',
             'mui-row-selected': rowSelected,
           },
           className,

--- a/src/components/TableBodyRow.js
+++ b/src/components/TableBodyRow.js
@@ -21,16 +21,16 @@ const defaultBodyRowStyles = theme => ({
     [theme.breakpoints.down('sm')]: {
       borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
       borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
-      padding:0,
-      margin:0,
+      padding: 0,
+      margin: 0,
     },
   },
   responsiveSimple: {
     [theme.breakpoints.down('xs')]: {
       borderTop: 'solid 2px rgba(0, 0, 0, 0.15)',
       borderBottom: 'solid 2px rgba(0, 0, 0, 0.15)',
-      padding:0,
-      margin:0,
+      padding: 0,
+      margin: 0,
     },
   },
 });

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -14,6 +14,11 @@ const defaultHeadStyles = theme => ({
       display: 'none',
     },
   },
+  responsiveSimple: {
+    [theme.breakpoints.down('xs')]: {
+      display: 'none',
+    },
+  },
 });
 
 class TableHead extends React.Component {
@@ -68,7 +73,11 @@ class TableHead extends React.Component {
     return (
       <MuiTableHead
         className={classNames({
-          [classes.responsiveStacked]: options.responsive === 'stacked' || options.responsive === 'stackedFullWidth',
+          [classes.responsiveStacked]:
+            options.responsive === 'vertical' ||
+            options.responsive === 'stacked' ||
+            options.responsive === 'stackedFullWidth',
+          [classes.responsiveSimple]: options.responsive === 'simple',
           [classes.main]: true,
         })}>
         <TableHeadRow>

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,12 @@ function warnDeprecated(warning) {
   }
 }
 
+function warnInfo(warning) {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(`${warning}`);
+  }
+}
+
 function getPageValue(count, rowsPerPage, page) {
   const totalPages = count <= rowsPerPage ? 1 : Math.ceil(count / rowsPerPage);
 
@@ -137,5 +143,6 @@ export {
   buildCSV,
   downloadCSV,
   warnDeprecated,
+  warnInfo,
   escapeDangerousCSVCharacters,
 };

--- a/test/MUIDataTableBodyCell.test.js
+++ b/test/MUIDataTableBodyCell.test.js
@@ -25,16 +25,20 @@ describe('<TableBodyCell />', function() {
     data = [
       ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
       ['John Walsh', 'Test Corp', 'Hartford', null],
-      ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
+      ['Bob Herm', 'Test Corp X', 'Tampa', 'FL'],
       ['James Houston', 'Test Corp', 'Dallas', 'TX'],
     ];
   });
 
   it('should execute "onCellClick" prop when clicked if provided', () => {
     var clickCount = 0;
+    var colIndex, rowIndex, colData;
     const options = {
-      onCellClick: () => {
+      onCellClick: (val, colMeta) => {
         clickCount++;
+        colIndex = colMeta.colIndex;
+        rowIndex = colMeta.rowIndex;
+        colData = val;
       }
     };
 
@@ -45,7 +49,29 @@ describe('<TableBodyCell />', function() {
       .at(0)
       .simulate('click');
     assert.strictEqual(clickCount, 1);
+    assert.strictEqual(colIndex, 0);
+    assert.strictEqual(rowIndex, 0);
+    assert.strictEqual(colData, 'Joe James');
+
+    fullWrapper
+      .find('[data-testid="MuiDataTableBodyCell-2-3"]')
+      .at(0)
+      .simulate('click');
+    assert.strictEqual(clickCount, 2);
+    assert.strictEqual(colIndex, 2);
+    assert.strictEqual(rowIndex, 3);
+    assert.strictEqual(colData, 'Dallas');
+
+    fullWrapper
+      .find('[data-testid="MuiDataTableBodyCell-1-2"]')
+      .at(0)
+      .simulate('click');
+    assert.strictEqual(clickCount, 3);
+    assert.strictEqual(colIndex, 1);
+    assert.strictEqual(rowIndex, 2);
+    assert.strictEqual(colData, 'Test Corp X');
 
   });
 
 });
+

--- a/test/MUIDataTableBodyCell.test.js
+++ b/test/MUIDataTableBodyCell.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { spy, stub } from 'sinon';
+import { mount, shallow } from 'enzyme';
+import { assert, expect, should } from 'chai';
+import MUIDataTable from '../src/MUIDataTable';
+import TableBodyCell from '../src/components/TableBodyCell';
+
+describe('<TableBodyCell />', function() {
+  let data;
+  let columns;
+
+  before(() => {
+    columns = [
+      {
+        name: 'Name',
+      },
+      'Company',
+      { name: 'City', label: 'City Label', options: { filterType: 'textField' } },
+      {
+        name: 'State',
+        options: { filterType: 'multiselect' },
+      },
+      { name: 'Empty', options: { empty: true, filterType: 'checkbox' } },
+    ];
+    data = [
+      ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
+      ['John Walsh', 'Test Corp', 'Hartford', null],
+      ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
+      ['James Houston', 'Test Corp', 'Dallas', 'TX'],
+    ];
+  });
+
+  it('should execute "onCellClick" prop when clicked if provided', () => {
+    var clickCount = 0;
+    const options = {
+      onCellClick: () => {
+        clickCount++;
+      }
+    };
+
+    const fullWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+
+    fullWrapper
+      .find('[data-testid="MuiDataTableBodyCell-0-0"]')
+      .at(0)
+      .simulate('click');
+    assert.strictEqual(clickCount, 1);
+
+  });
+
+});


### PR DESCRIPTION
This PR aims to fix the issues with the "responsive" option. These are:

* There is no easy way to set the height or maxHeight of the table.
* The "stacked" mode appears misaligned since version 2.14.0.
* The "stacked" mode doesn't handle long strings of text (it overflows off the table).
* The responsive option names are confusing.

This PR splits the setting of the table height away from the responsive parameter. It creates 3 new responsive options:

* "vertical": This mode replaces "stacked" mode. Long strings of text are now correctly handled and alignment appears correct.
* "standard": This mode replaces "scrollMaxHeight" mode.
* "simple": This mode mimics the design in this issue: https://github.com/gregnb/mui-datatables/issues/1188

To deal with table height, two new options are introduced:

* tableBodyHeight: Set the height of the table.
* tableBodyMaxHeight: Set the max height of the table.

If both are set, the table will use tableBodyMaxHeight (though maybe it makes more sense to use tableBodyHeight?). These options are subtly different. I've updated the "Simple" example so that it's easy to toggle between various modes and set various heights.

All old responsive modes will continue to be supported in v3, but will be deprecated.

These updates can be tried [live in this codesandbox](https://codesandbox.io/s/github/gregnb/mui-datatables/tree/responsiveRefactor) - See the "Simple" example. Feedback is greatly appreciated.