### PR TITLE
Added customTableBodyFooterRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The component accepts the following props:
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
 |**`customFooter`**|function||Render a custom table footer. `function(count, page, rowsPerPage, changeRowsPerPage, changePage, `[`textLabels: object`](https://github.com/gregnb/mui-datatables/blob/master/src/textLabels.js)`) => string`&#124;` React Component` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
+|**`customTableBodyFooterRender`**|function||Render a footer under the table body but above the table's standard footer. This is useful for creating footers for individual columns. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`

--- a/examples/customize-footer/index.js
+++ b/examples/customize-footer/index.js
@@ -1,69 +1,167 @@
-import React from "react";
+import React, {useState} from "react";
 import MUIDataTable from "../../src/";
 import CustomFooter from "./CustomFooter";
+import {makeStyles} from "@material-ui/core/styles";
+import TableFooter from "@material-ui/core/TableFooter";
+import TableRow from "@material-ui/core/TableRow";
+import TableCell from "@material-ui/core/TableCell";
+import Switch from '@material-ui/core/Switch';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import classnames from 'classnames';
 
-class Example extends React.Component {
-
-  render() {
-
-    const columns = ["Name", "Title", "Location", "Age", "Salary"];
-
-    let data = [
-      ["Gabby George", "Business Analyst", "Minneapolis", 30, 100000],
-      ["Aiden Lloyd", "Business Consultant", "Dallas",  55, 200000],
-      ["Jaden Collins", "Attorney", "Santa Ana", 27, 500000],
-      ["Franky Rees", "Business Analyst", "St. Petersburg", 22, 50000],
-      ["Aaren Rose", "Business Consultant", "Toledo", 28, 75000],
-      ["Blake Duncan", "Business Management Analyst", "San Diego", 65, 94000],
-      ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, 210000],
-      ["Lane Wilson", "Commercial Specialist", "Omaha", 19, 65000],
-      ["Robin Duncan", "Business Analyst", "Los Angeles", 20, 77000],
-      ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, 135000],
-      ["Harper White", "Attorney", "Pittsburgh", 52, 420000],
-      ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, 150000],
-      ["Frankie Long", "Industrial Analyst", "Austin", 31, 170000],
-      ["Brynn Robbins", "Business Analyst", "Norfolk", 22, 90000],
-      ["Justice Mann", "Business Consultant", "Chicago", 24, 133000],
-      ["Addison Navarro", "Business Management Analyst", "New York", 50, 295000],
-      ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, 200000],
-      ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, 400000],
-      ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, 110000],
-      ["Danny Leon", "Computer Scientist", "Newark", 60, 220000],
-      ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, 180000],
-      ["Jesse Hall", "Business Analyst", "Baltimore", 44, 99000],
-      ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, 90000],
-      ["Terry Macdonald", "Commercial Specialist", "Miami", 39, 140000],
-      ["Justice Mccarthy", "Attorney", "Tucson", 26, 330000],
-      ["Silver Carey", "Computer Scientist", "Memphis", 47, 250000],
-      ["Franky Miles", "Industrial Analyst", "Buffalo", 49, 190000],
-      ["Glen Nixon", "Corporate Counselor", "Arlington", 44, 80000],
-      ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, 45000],
-      ["Mason Ray", "Computer Scientist", "San Francisco", 39, 142000]
-    ];
-
-    const options = {
-      filter: true,
-      filterType: 'dropdown',
-      responsive: 'stacked',
-      rowsPerPage: 10,
-      customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => {
-        return (  
-          <CustomFooter 
-            count={count} 
-            page={page} 
-            rowsPerPage={rowsPerPage} 
-            changeRowsPerPage={changeRowsPerPage} 
-            changePage={changePage} 
-            textLabels={textLabels} />
-        );
-      }
-    };
-
-    return (
-      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
-    );
-
+const useStyles = makeStyles(theme => ({
+  footerCell: {
+    backgroundColor: theme.palette.background.paper,
+    borderBottom:'none'
+  },
+  stickyFooterCell: {
+    position: 'sticky',
+    bottom: 0,
+    zIndex: 100,
   }
+}));
+
+function Example() {
+
+  const [resizableColumns, setResizableColumns] = useState(false);
+  const [stickyFooter, setStickyFooter] = useState(true);
+  const classes = useStyles();
+
+  const columns = ["Name", "Title", "Location", "Age", "Salary"];
+
+  let data = [
+    ["Gabby George", "Business Analyst", "Minneapolis", 30, 100000],
+    ["Aiden Lloyd", "Business Consultant", "Dallas",  55, 200000],
+    ["Jaden Collins", "Attorney", "Santa Ana", 27, 500000],
+    ["Franky Rees", "Business Analyst", "St. Petersburg", 22, 50000],
+    ["Aaren Rose", "Business Consultant", "Toledo", 28, 75000],
+    ["Blake Duncan", "Business Management Analyst", "San Diego", 65, 94000],
+    ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, 210000],
+    ["Lane Wilson", "Commercial Specialist", "Omaha", 19, 65000],
+    ["Robin Duncan", "Business Analyst", "Los Angeles", 20, 77000],
+    ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, 135000],
+    ["Harper White", "Attorney", "Pittsburgh", 52, 420000],
+    ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, 150000],
+    ["Frankie Long", "Industrial Analyst", "Austin", 31, 170000],
+    ["Brynn Robbins", "Business Analyst", "Norfolk", 22, 90000],
+    ["Justice Mann", "Business Consultant", "Chicago", 24, 133000],
+    ["Addison Navarro", "Business Management Analyst", "New York", 50, 295000],
+    ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, 200000],
+    ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, 400000],
+    ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, 110000],
+    ["Danny Leon", "Computer Scientist", "Newark", 60, 220000],
+    ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, 180000],
+    ["Jesse Hall", "Business Analyst", "Baltimore", 44, 99000],
+    ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, 90000],
+    ["Terry Macdonald", "Commercial Specialist", "Miami", 39, 140000],
+    ["Justice Mccarthy", "Attorney", "Tucson", 26, 330000],
+    ["Silver Carey", "Computer Scientist", "Memphis", 47, 250000],
+    ["Franky Miles", "Industrial Analyst", "Buffalo", 49, 190000],
+    ["Glen Nixon", "Corporate Counselor", "Arlington", 44, 80000],
+    ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, 45000],
+    ["Mason Ray", "Computer Scientist", "San Francisco", 39, 142000]
+  ];
+
+  const footerClasses = classnames({
+      [classes.footerCell]: true,
+      [classes.stickyFooterCell]: stickyFooter,
+    });
+
+  const options = {
+    filter: true,
+    filterType: 'dropdown',
+    responsive: 'scrollMaxHeight',
+    rowsPerPage: 10,
+    resizableColumns: resizableColumns,
+    customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage, textLabels) => {
+      return (  
+        <CustomFooter 
+          count={count} 
+          page={page} 
+          rowsPerPage={rowsPerPage} 
+          changeRowsPerPage={changeRowsPerPage} 
+          changePage={changePage} 
+          textLabels={textLabels} />
+      );
+    },
+    customTableBodyFooter: function(opts) {
+      console.dir(opts);
+
+      let avgAge = opts.data.reduce( (accu, item) => {
+        return accu + item.data[3];
+      }, 0) / opts.data.length;
+
+      let avgSalary = opts.data.reduce( (accu, item) => {
+        return accu + item.data[4];
+      }, 0) / opts.data.length;
+
+      avgAge = Math.round(avgAge);
+      avgSalary = Math.round(avgSalary);
+
+      return (
+        <TableFooter className={footerClasses}>
+          <TableRow>
+            {opts.selectableRows !== 'none' ? 
+                <TableCell className={footerClasses} />
+                : null
+            }
+            {opts.columns.map((col, index) => {
+              if (col.display === 'true') {
+                if (col.name === 'Age') {
+                  return (
+                    <TableCell key={index} className={footerClasses} >
+                      Avg: {avgAge}
+                    </TableCell>
+                  );
+                } else if (col.name === 'Salary') {
+                  return (
+                    <TableCell key={index} className={footerClasses}>
+                      Avg: {avgSalary}
+                    </TableCell>
+                  );
+                } else {
+                  return (<TableCell key={index} className={footerClasses} />);
+                }
+              }
+              return null;
+            })}
+
+          </TableRow>
+        </TableFooter>
+      );
+    }
+  };
+
+  return (
+    <>
+      <FormGroup row>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={resizableColumns}
+              onChange={(e) => setResizableColumns(e.target.checked)}
+              value="denseTable"
+              color="primary"
+            />
+          }
+          label="Resizable Columns"
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={stickyFooter}
+              onChange={(e) => setStickyFooter(e.target.checked)}
+              value="stacked"
+              color="primary"
+            />
+          }
+          label="Sticky Footer"
+        />
+      </FormGroup>
+      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+    </>
+  );
 }
 
 export default Example;

--- a/examples/customize-footer/index.js
+++ b/examples/customize-footer/index.js
@@ -85,7 +85,7 @@ function Example() {
           textLabels={textLabels} />
       );
     },
-    customTableBodyFooter: function(opts) {
+    customTableBodyFooterRender: function(opts) {
       console.dir(opts);
 
       let avgAge = opts.data.reduce( (accu, item) => {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -949,16 +949,11 @@ class MUIDataTable extends React.Component {
         var cb = this.options.onViewColumnsChange || this.options.onColumnViewChange;
 
         if (cb) {
-          cb(
-            this.state.columns[index].name,
-            this.state.columns[index].display === 'true' ? 'add' : 'remove',
-          );
+          cb(this.state.columns[index].name, this.state.columns[index].display === 'true' ? 'add' : 'remove');
         }
 
         if (this.options.onColumnViewChange) {
-          warnDeprecated(
-            'onColumnViewChange has been changed to onViewColumnsChange.',
-          );
+          warnDeprecated('onColumnViewChange has been changed to onViewColumnsChange.');
         }
       },
     );
@@ -1636,6 +1631,15 @@ class MUIDataTable extends React.Component {
               options={this.options}
               filterList={filterList}
             />
+            {this.options.customTableBodyFooter
+              ? this.options.customTableBodyFooter({
+                  data: displayData,
+                  count: rowCount,
+                  columns,
+                  selectedRows,
+                  selectableRows: this.options.selectableRows
+                })
+              : null}
           </MuiTable>
         </div>
         <TableFooterComponent

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1631,8 +1631,8 @@ class MUIDataTable extends React.Component {
               options={this.options}
               filterList={filterList}
             />
-            {this.options.customTableBodyFooter
-              ? this.options.customTableBodyFooter({
+            {this.options.customTableBodyFooterRender
+              ? this.options.customTableBodyFooterRender({
                   data: displayData,
                   count: rowCount,
                   columns,

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -12,6 +12,9 @@ import getTextLabels from '../src/textLabels';
 import Chip from '@material-ui/core/Chip';
 import Cities from '../examples/component/cities';
 import { getCollatorComparator } from '../src/utils';
+import TableFooter from "@material-ui/core/TableFooter";
+import TableRow from "@material-ui/core/TableRow";
+import TableCell from "@material-ui/core/TableCell";
 
 describe('<MUIDataTable />', function() {
   let data;
@@ -403,6 +406,8 @@ describe('<MUIDataTable />', function() {
         fullWrapper.setProps({ data });
         fullWrapper.update();
         assert.strictEqual(fullWrapper.find('tbody tr').length, 4);
+
+        fullWrapper.unmount();
         done();
       }, 10);
     });
@@ -462,6 +467,7 @@ describe('<MUIDataTable />', function() {
     props = fullWrapper.props();
 
     assert.deepEqual(props.options, newOptions);
+    fullWrapper.unmount();
   });
 
   it('should correctly re-build internal table data while maintaining pagination after state change', () => {
@@ -531,6 +537,7 @@ describe('<MUIDataTable />', function() {
       ['Harry Smith', 'Test Corp', 'Philadelphia', 'PA', undefined],
     ];
     assert.deepEqual(props.data, expectedResult);
+    fullWrapper.unmount();
   });
 
   it('should not re-build internal table data and displayData structure with no prop change to data or columns', () => {
@@ -933,6 +940,20 @@ describe('<MUIDataTable />', function() {
     instance.resetFilters();
     table.update();
     assert.strictEqual(type, 'reset');
+  });
+
+  it('should render a footer after the tbody element when customTableBodyFooterRender is called', () => {
+    const options = {
+
+    };
+    
+    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+    const actualResult = mountWrapper.find("#custom_column_footer");
+    assert.strictEqual(actualResult.exists(), false);
+
+    console.log( mountWrapper.find("table").length );
+
+    mountWrapper.unmount();
   });
 
   it('should properly set searchText when calling searchTextUpdate method', () => {


### PR DESCRIPTION
This PR aims to solve the main problem brought up in https://github.com/gregnb/mui-datatables/pull/1266, which is that it is not currently possible for a column to have it's own footer cell. This stems from the footer of the table being wrapped in its [own table](https://github.com/gregnb/mui-datatables/blob/master/src/components/TableFooter.js#L17). There are good reasons for this (ex: the resizable columns feature), and while refactoring the footer to not be inside its own table element might be possible, it would be messy and potentially lead to bugs.

In order to allow columns to have their own footer, this solution instead proposes a new option called customTableBodyFooterRender  which allows the user to render a footer under the table body and above the table's pagination footer. The customize-footer example has been updated to show how this would work.

The renderer leaves all of the work of creating this footer to the user. The reason for this is to allow for maximum customization, since a footer like this isn't typical but is useful in some cases (like the statics example given in the original PR).