### PR TITLE
Added confirmFilters option (deprecates serverSideFilterList)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The component accepts the following props:
 |**`onSearchOpen`**|function||Callback function that triggers when the searchbox opens. `function() => void`
 |**`onFilterDialogOpen`**|function||Callback function that triggers when the filter dialog opens. `function() => void`
 |**`onFilterDialogClose`**|function||Callback function that triggers when the filter dialog closes. `function() => void`
-|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array, type: enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom', 'chip', 'reset'), changedColumnIndex) => void`
+|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array, type: enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom', 'chip', 'reset'), changedColumnIndex, displayData) => void`
 |**`onFilterConfirm`**|function||Callback function that is triggered when a user presses the "confirm" button on the filter popover. This occurs only if you've set **confirmFilters** option to true. `function(filterList: array) => void` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
 |**`onSearchClose`**|function||Callback function that triggers when the searchbox closes. `function() => void`
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The component accepts the following props:
 |**`page`**|number||User provided starting page for pagination
 |**`count`**|number||User provided override for total number of rows
 |**`serverSide`**|boolean|false|Enable remote data source
-|**`serverSideFilterList`**|array|[]|Sets the filter list display when using serverSide: true
 |**`rowsSelected`**|array||User provided selected rows
 |**`rowsExpanded`**|array||User provided expanded rows
 |**`filterType`**|string||Choice of filtering view. `enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom')`
@@ -177,7 +176,7 @@ The component accepts the following props:
 |**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`customSearchRender `**|function||Render a custom table search. `customSearchRender(searchText: string, handleSearch, hideSearch, options) => React Component`
-|**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(filterList: array) => React Component`
+|**`customFilterDialogFooter `**|function||Add a custom footer to the filter dialog. `customFilterDialogFooter(curentFilterList: array, applyFilters: function) => React Component`
 |**`elevation`**|number|4|Shadow depth applied to Paper component
 |**`caseSensitive `**|boolean|false|Enable/disable case sensitivity for search
 |**`responsive`**|string|'stacked'|Enable/disable responsive table views. Options: 'stacked', 'scrollMaxHeight' (limits height of table), 'scrollFullHeight' (table takes on as much height as needed to display all rows set in rowsPerPage), 'scrollFullHeightFullWidth' (same as 'scrollFullHeight' except that paper container wraps the table and the width takes the full browser window), 'stackedFullWidth' (same as stacked with the addition of the paper container changes with 'scrollFullHeightFullWidth') **('scroll' option has been deprecated in favor of `scrollMaxHeight`)**
@@ -211,7 +210,8 @@ The component accepts the following props:
 |**`onSearchOpen`**|function||Callback function that triggers when the searchbox opens. `function() => void`
 |**`onFilterDialogOpen`**|function||Callback function that triggers when the filter dialog opens. `function() => void`
 |**`onFilterDialogClose`**|function||Callback function that triggers when the filter dialog closes. `function() => void`
-|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array, type: enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom', 'chip', 'reset')) => void`
+|**`onFilterChange`**|function||Callback function that triggers when filters have changed. `function(changedColumn: string, filterList: array, type: enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom', 'chip', 'reset'), changedColumnIndex) => void`
+|**`onFilterConfirm`**|function||Callback function that is triggered when a user presses the "confirm" button on the filter popover. This occurs only if you've set **confirmFilters** option to true. `function(filterList: array) => void` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
 |**`onSearchClose`**|function||Callback function that triggers when the searchbox closes. `function() => void`
 |**`onColumnSortChange`**|function||Callback function that triggers when a column has been sorted. `function(changedColumn: string, direction: string) => void`
 |**`onViewColumnsChange`**|function||Callback function that triggers when a column view has been changed. `function(changedColumn: string, action: string) => void`
@@ -221,6 +221,7 @@ The component accepts the following props:
 |**`setTableProps`**|function||Is called for the table and allows you to return custom props for the table based on its data. `function() => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`sortOrder`**|object|{}|Sets the column to sort by and its sort direction. To remove/reset sorting, input in an empty object. The object options are the column name and the direction: `name: string, direction: enum('asc', 'desc')` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-columns/index.js)
 |**`selectToolbarPlacement`**|string|'replace'|Controls the visibility of the Select Toolbar, options are 'replace' (select toolbar replaces default toolbar when a row is selected), 'above' (select toolbar will appear above default toolbar when a row is selected) and 'none' (select toolbar will never appear)
+|**`confirmFilters`**|boolean|false|Works in conjunction with the **customFilterDialogFooter** option and makes it so filters have to be confirmed before being applied to the table. When this option is true, the customFilterDialogFooter callback will receive an applyFilters function which, when called, will apply the filters to the table. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/serverside-filters/index.js)
 
 ## Customize Columns
 

--- a/examples/customize-filter/index.js
+++ b/examples/customize-filter/index.js
@@ -29,6 +29,7 @@ class Example extends React.Component {
             renderValue: v => v ? v.replace(/^(\w).* (.*)$/, '$1. $2') : ''
           },
           display: 'excluded',
+          filterType: 'textField'
         },
       },
       {

--- a/examples/large-data-set/index.js
+++ b/examples/large-data-set/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src/";
 import { debounceSearchRender } from "../../src/";
+import { Button } from '@material-ui/core';
 
 class Example extends React.Component {
 
@@ -61,8 +62,6 @@ class Example extends React.Component {
         options: {
           filter: true,
           customBodyRender: (val, tableMeta) => {
-            console.log(val);
-            console.dir(tableMeta);
             return val;
           }
         }
@@ -123,6 +122,18 @@ class Example extends React.Component {
       filterType: 'dropdown',
       responsive: 'scrollMaxHeight',
       customSearchRender: debounceSearchRender(500),
+
+      // These next two options allow you to make it so filters need to be confirmed.
+      confirmFilters: true,
+
+      // Calling the applyNewFilters parameter applies the selected filters to the table
+      customFilterDialogFooter: (currentFilterList, applyNewFilters) => {
+        return (
+          <div style={{ marginTop: '40px' }}>
+            <Button variant="contained" onClick={applyNewFilters}>Apply Filters</Button>
+          </div>
+        );
+      }
     };
 
     return (

--- a/examples/serverside-filters/index.js
+++ b/examples/serverside-filters/index.js
@@ -3,43 +3,43 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import MUIDataTable from '../../src';
 
+const theData = [
+  ['Gabby George', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
+  ['Aiden Lloyd', 'Business Consultant', 'Dallas', 55, '$200,000'],
+  ['Jaden Collins', 'Attorney', 'Santa Ana', 27, '$500,000'],
+  ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
+  ['Aaren Rose', 'Business Consultant', 'Toledo', 28, '$75,000'],
+  ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
+  ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
+  ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
+  ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
+  ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
+  ['Harper White', 'Attorney', 'Pittsburgh', 52, '$420,000'],
+  ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
+  ['Frankie Long', 'Industrial Analyst', 'Austin', 31, '$170,000'],
+  ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, '$90,000'],
+  ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000'],
+  ['Addison Navarro', 'Business Management Analyst', 'New York', 50, '$295,000'],
+  ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
+  ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
+  ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
+  ['Danny Leon', 'Computer Scientist', 'Newark', 60, '$220,000'],
+  ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
+  ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, '$99,000'],
+  ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
+  ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, '$140,000'],
+  ['Justice Mccarthy', 'Attorney', 'Tucson', 26, '$330,000'],
+  ['Silver Carey', 'Computer Scientist', 'Memphis', 47, '$250,000'],
+  ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
+  ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
+  ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
+  ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
+];
+
 class Example extends React.Component {
   state = {
-    serverSideFilterList: [],
-    filters: [[], [], [], [], []],
     isLoading: false,
-    data: [
-      ['Gabby George', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
-      ['Aiden Lloyd', 'Business Consultant', 'Dallas', 55, '$200,000'],
-      ['Jaden Collins', 'Attorney', 'Santa Ana', 27, '$500,000'],
-      ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
-      ['Aaren Rose', 'Business Consultant', 'Toledo', 28, '$75,000'],
-      ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
-      ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
-      ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
-      ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
-      ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
-      ['Harper White', 'Attorney', 'Pittsburgh', 52, '$420,000'],
-      ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
-      ['Frankie Long', 'Industrial Analyst', 'Austin', 31, '$170,000'],
-      ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, '$90,000'],
-      ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000'],
-      ['Addison Navarro', 'Business Management Analyst', 'New York', 50, '$295,000'],
-      ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
-      ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
-      ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
-      ['Danny Leon', 'Computer Scientist', 'Newark', 60, '$220,000'],
-      ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
-      ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, '$99,000'],
-      ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
-      ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, '$140,000'],
-      ['Justice Mccarthy', 'Attorney', 'Tucson', 26, '$330,000'],
-      ['Silver Carey', 'Computer Scientist', 'Memphis', 47, '$250,000'],
-      ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
-      ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
-      ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
-      ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
-    ]
+    data: theData
   };
 
   // mock async function
@@ -47,53 +47,31 @@ class Example extends React.Component {
     return new Promise(resolve => {
       window.setTimeout(
         () => {
-          const data = [
-            ['Gabby George', 'Business Analyst', 'Minneapolis', 30, '$100,000'],
-            ['Aiden Lloyd', 'Business Consultant', 'Dallas', 55, '$200,000'],
-            ['Jaden Collins', 'Attorney', 'Santa Ana', 27, '$500,000'],
-            ['Franky Rees', 'Business Analyst', 'St. Petersburg', 22, '$50,000'],
-            ['Aaren Rose', 'Business Consultant', 'Toledo', 28, '$75,000'],
-            ['Blake Duncan', 'Business Management Analyst', 'San Diego', 65, '$94,000'],
-            ['Frankie Parry', 'Agency Legal Counsel', 'Jacksonville', 71, '$210,000'],
-            ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
-            ['Robin Duncan', 'Business Analyst', 'Los Angeles', 20, '$77,000'],
-            ['Mel Brooks', 'Business Consultant', 'Oklahoma City', 37, '$135,000'],
-            ['Harper White', 'Attorney', 'Pittsburgh', 52, '$420,000'],
-            ['Kris Humphrey', 'Agency Legal Counsel', 'Laredo', 30, '$150,000'],
-            ['Frankie Long', 'Industrial Analyst', 'Austin', 31, '$170,000'],
-            ['Brynn Robbins', 'Business Analyst', 'Norfolk', 22, '$90,000'],
-            ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000'],
-            ['Addison Navarro', 'Business Management Analyst', 'New York', 50, '$295,000'],
-            ['Jesse Welch', 'Agency Legal Counsel', 'Seattle', 28, '$200,000'],
-            ['Eli Mejia', 'Commercial Specialist', 'Long Beach', 65, '$400,000'],
-            ['Gene Leblanc', 'Industrial Analyst', 'Hartford', 34, '$110,000'],
-            ['Danny Leon', 'Computer Scientist', 'Newark', 60, '$220,000'],
-            ['Lane Lee', 'Corporate Counselor', 'Cincinnati', 52, '$180,000'],
-            ['Jesse Hall', 'Business Analyst', 'Baltimore', 44, '$99,000'],
-            ['Danni Hudson', 'Agency Legal Counsel', 'Tampa', 37, '$90,000'],
-            ['Terry Macdonald', 'Commercial Specialist', 'Miami', 39, '$140,000'],
-            ['Justice Mccarthy', 'Attorney', 'Tucson', 26, '$330,000'],
-            ['Silver Carey', 'Computer Scientist', 'Memphis', 47, '$250,000'],
-            ['Franky Miles', 'Industrial Analyst', 'Buffalo', 49, '$190,000'],
-            ['Glen Nixon', 'Corporate Counselor', 'Arlington', 44, '$80,000'],
-            ['Gabby Strickland', 'Business Process Consultant', 'Scottsdale', 26, '$45,000'],
-            ['Mason Ray', 'Computer Scientist', 'San Francisco', 39, '$142,000'],
-          ];
-          const newData = [
-            ['Lane Wilson', 'Commercial Specialist', 'Chicago', 19, '$65,000'],
-            ['Justice Mann', 'Business Consultant', 'Chicago', 24, '$133,000']
-          ];
+          const data = theData;
 
           if (
-            !filterList[0].length
-            && !filterList[1].length
-            && !filterList[2].length
-            && !filterList[3].length
-            && !filterList[4].length
+            filterList.reduce( (accu, cur) => accu + cur.length, 0) === 0
           ) {
             resolve({ data });
           } else {
-            resolve({ data: newData });
+
+            /*
+              This code simulates filtering that would occur on the back-end
+            */
+            var filteredData = data.filter(row => {
+              var ret = true;
+
+              for (var ii = 0; ii <= 4; ii++) {
+                if (filterList[ii] && filterList[ii].length) {
+                  ret = ret && filterList[ii].filter(ff => {
+                    return row[ii] == ff;
+                  }).length > 0;
+                }
+              }
+              return ret;
+            });
+
+            resolve({ data: filteredData });
           }
         },
         2000
@@ -101,14 +79,14 @@ class Example extends React.Component {
     });
   }
 
-  handleFilterSubmit = filterList => () => {
-    console.log('Submitting filters: ', filterList);
+  handleFilterSubmit = applyFilters => {
+    let filterList = applyFilters();
 
-    this.setState({ isLoading: true, filters: filterList });
+    this.setState({ isLoading: true });
 
     // fake async request
     this.xhrRequest(`/myApiServer?filters=${filterList}`, filterList).then(res => {
-      this.setState({ isLoading: false, data: res.data, serverSideFilterList: filterList });
+      this.setState({ isLoading: false, data: res.data });
     });
   };
 
@@ -118,7 +96,6 @@ class Example extends React.Component {
         name: 'Name',
         options: {
           filter: true,
-          filterList: this.state.filters[0],
         },
       },
       {
@@ -126,38 +103,53 @@ class Example extends React.Component {
         name: 'Title',
         options: {
           filter: true,
-          filterList: this.state.filters[1],
         },
       },
       {
         name: 'Location',
         options: {
           filter: true,
-          filterList: this.state.filters[2],
         },
       },
       {
         name: 'Age',
         options: {
           filter: true,
-          filterList: this.state.filters[3],
         },
       },
       {
         name: 'Salary',
         options: {
           filter: true,
-          filterList: this.state.filters[4],
         },
       },
     ];
 
     const options = {
-      filter: true,
-      serverSideFilterList: this.state.serverSideFilterList,
+      filter: true, // show the filter icon in the toolbar (true by default)
       filterType: 'dropdown',
       responsive: 'scrollMaxHeight',
       serverSide: true,
+
+      // makes it so filters have to be "confirmed" before being applied to the 
+      // table's internal filterList
+      confirmFilters: true, 
+
+      // Calling the applyNewFilters parameter applies the selected filters to the table 
+      customFilterDialogFooter: (currentFilterList, applyNewFilters) => {
+        return (
+          <div style={{ marginTop: '40px' }}>
+            <Button variant="contained" onClick={() => this.handleFilterSubmit(applyNewFilters)}>Apply Filters</Button>
+          </div>
+        );
+      },
+
+      // callback that gets executed when filters are confirmed
+      onFilterConfirm: (filterList) => {
+        console.log('onFilterConfirm');
+        console.dir(filterList);
+      },
+
       onFilterDialogOpen: () => {
         console.log('filter dialog opened');
       },
@@ -166,18 +158,11 @@ class Example extends React.Component {
       },
       onFilterChange: (column, filterList, type) => {
         if (type === 'chip') {
+          var newFilters = () => (filterList);
           console.log('updating filters via chip');
-          this.handleFilterSubmit(filterList)();
+          this.handleFilterSubmit(newFilters);
         }
       },
-      customFilterDialogFooter: filterList => {
-        return (
-          <div style={{ marginTop: '40px' }}>
-            <Button variant="contained" onClick={this.handleFilterSubmit(filterList)}>Apply Filters*</Button>
-            <p><em>*(Simulates selecting "Chicago" from "Location")</em></p>
-          </div>
-        );
-      }
     };
 
     return (

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -29,6 +29,13 @@ class Example extends React.Component {
       filter: true,
       filterType: 'dropdown',
       responsive: 'stacked',
+      onFilterChange: (column, filterList, type) => {
+        
+        console.log('filterList');
+        console.dir(filterList);
+
+
+      },
     };
 
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "2.15.0",
+  "version": "3.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1193,7 +1193,7 @@ class MUIDataTable extends React.Component {
       () => {
         this.setTableAction('filterChange');
         if (this.options.onFilterChange) {
-          this.options.onFilterChange(column, this.state.filterList, type, index);
+          this.options.onFilterChange(column, this.state.filterList, type, index, this.state.displayData);
         }
         next && next(this.state.filterList);
       },

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -27,7 +27,13 @@ class Popover extends React.Component {
      */
     if (this.state.open === true) {
       this.anchorEl = findDOMNode(this.anchorEl);
-      this.popoverActions.updatePosition();
+      if (this.popoverActions) {
+        this.popoverActions.updatePosition();
+      }
+      const shouldHide = (typeof this.props.hide === 'boolean') ? this.props.hide : false;
+      if (shouldHide) {
+        this.handleRequestClose();
+      }
     }
   }
 
@@ -47,7 +53,7 @@ class Popover extends React.Component {
   };
 
   render() {
-    const { className, placement, trigger, refExit, content, ...providedProps } = this.props;
+    const { className, placement, trigger, refExit, content, hide, ...providedProps } = this.props;
     let closeIconClass;
     if (providedProps.classes && providedProps.classes.closeIcon) {
       closeIconClass = providedProps.classes.closeIcon;

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -252,6 +252,7 @@ class TableFilter extends React.Component {
             fullWidth
             label={column.label}
             value={filterList[index].toString() || ''}
+            data-testid={"filtertextfield-" + column.name}
             onChange={event => this.handleTextFieldChange(event, index, column.name)}
           />
         </FormControl>

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -15,6 +15,7 @@ import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
 
 export const defaultFilterStyles = theme => ({
   root: {
@@ -101,30 +102,67 @@ class TableFilter extends React.Component {
     classes: PropTypes.object,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      filterList: cloneDeep(props.filterList),
+    };
+  }
+
+  filterUpdate = (index, value, column, type, customUpdate) => {
+    let newFilterList = this.state.filterList.slice(0);
+
+    this.props.updateFilterByType(newFilterList, index, value, type, customUpdate);
+    this.setState({
+      filterList: newFilterList,
+    });
+  };
+
   handleCheckboxChange = (index, value, column) => {
-    this.props.onFilterUpdate(index, value, column, 'checkbox');
+    this.filterUpdate(index, value, column, 'checkbox');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'checkbox');
+    }
   };
 
   handleDropdownChange = (event, index, column) => {
     const labelFilterAll = this.props.options.textLabels.filter.all;
     const value = event.target.value === labelFilterAll ? [] : [event.target.value];
-    this.props.onFilterUpdate(index, value, column, 'dropdown');
+    this.filterUpdate(index, value, column, 'dropdown');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'dropdown');
+    }
   };
 
   handleMultiselectChange = (index, value, column) => {
-    this.props.onFilterUpdate(index, value, column, 'multiselect');
+    this.filterUpdate(index, value, column, 'multiselect');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column, 'multiselect');
+    }
   };
 
   handleTextFieldChange = (event, index, column) => {
-    this.props.onFilterUpdate(index, event.target.value, column, 'textField');
+    this.filterUpdate(index, event.target.value, column, 'textField');
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, event.target.value, column, 'textField');
+    }
   };
 
   handleCustomChange = (value, index, column) => {
-    this.props.onFilterUpdate(index, value, column.name, column.filterType);
+    this.filterUpdate(index, value, column.name, column.filterType);
+
+    if (this.props.options.confirmFilters !== true) {
+      this.props.onFilterUpdate(index, value, column.name, column.filterType);
+    }
   };
 
   renderCheckbox(column, index) {
-    const { classes, filterData, filterList } = this.props;
+    const { classes, filterData } = this.props;
+    const { filterList } = this.state;
     const renderItem =
       column.filterOptions && column.filterOptions.renderValue ? column.filterOptions.renderValue : v => v;
 
@@ -168,7 +206,8 @@ class TableFilter extends React.Component {
   }
 
   renderSelect(column, index) {
-    const { classes, filterData, filterList, options } = this.props;
+    const { classes, filterData, options } = this.props;
+    const { filterList } = this.state;
     const textLabels = options.textLabels.filter;
     const renderItem =
       column.filterOptions && column.filterOptions.renderValue
@@ -200,7 +239,8 @@ class TableFilter extends React.Component {
   }
 
   renderTextField(column, index) {
-    const { classes, filterList } = this.props;
+    const { classes } = this.props;
+    const { filterList } = this.state;
     if (column.filterOptions && column.filterOptions.renderValue) {
       console.error('Custom renderItem not supported for textField filters');
     }
@@ -220,7 +260,8 @@ class TableFilter extends React.Component {
   }
 
   renderMultiselect(column, index) {
-    const { classes, filterData, filterList } = this.props;
+    const { classes, filterData } = this.props;
+    const { filterList } = this.state;
     const renderItem =
       column.filterOptions && column.filterOptions.renderValue ? column.filterOptions.renderValue : v => v;
     return (
@@ -256,7 +297,8 @@ class TableFilter extends React.Component {
   }
 
   renderCustomField(column, index) {
-    const { classes, filterData, filterList, options } = this.props;
+    const { classes, filterData, options } = this.props;
+    const { filterList } = this.state;
     const display =
       (column.filterOptions && column.filterOptions.display) ||
       (options.filterOptions && options.filterOptions.display);
@@ -277,6 +319,30 @@ class TableFilter extends React.Component {
       </GridListTile>
     );
   }
+
+  applyFilters = () => {
+    this.state.filterList.forEach((filter, index) => {
+      this.props.onFilterUpdate(index, filter, this.props.columns[index], 'custom');
+    });
+
+    this.props.handleClose(); // close filter dialog popover
+
+    if (this.props.options.onFilterConfirm) {
+      this.props.options.onFilterConfirm(this.state.filterList);
+    }
+
+    return this.state.filterList;
+  };
+
+  resetFilters = () => {
+    if (this.props.options.confirmFilters === true) {
+      this.setState({
+        filterList: this.props.columns.map(() => []),
+      });
+    } else {
+      this.props.onFilterReset();
+    }
+  };
 
   render() {
     const { classes, columns, options, onFilterReset, customFooter, filterList } = this.props;
@@ -300,7 +366,7 @@ class TableFilter extends React.Component {
               tabIndex={0}
               aria-label={textLabels.reset}
               data-testid={'filterReset-button'}
-              onClick={onFilterReset}>
+              onClick={this.resetFilters}>
               {textLabels.reset}
             </Button>
           </div>
@@ -322,7 +388,7 @@ class TableFilter extends React.Component {
             }
           })}
         </GridList>
-        {customFooter ? customFooter(filterList) : ''}
+        {customFooter ? customFooter(filterList, this.applyFilters) : ''}
       </div>
     );
   }

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -115,7 +115,9 @@ class TableFilterList extends React.Component {
     };
 
     return (
-      <div className={classes.root}>{serverSide ? getFilterList(serverSideFilterList) : getFilterList(filterList)}</div>
+      <div className={classes.root}>
+        {serverSide && serverSideFilterList ? getFilterList(serverSideFilterList) : getFilterList(filterList)}
+      </div>
     );
   }
 }

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -253,11 +253,21 @@ class TableToolbar extends React.Component {
       title,
       tableRef,
       components = {},
+      updateFilterByType,
     } = this.props;
 
     const Tooltip = components.Tooltip || MuiTooltip;
     const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
     const { showSearch, searchText } = this.state;
+
+    const filterPopoverExit = () => {
+      this.setState({hideFilterPopover: false});
+      this.setActiveIcon.bind(null);
+    };
+
+    const closeFilterPopover = () => {
+      this.setState({hideFilterPopover: true});
+    };
 
     return (
       <Toolbar
@@ -354,7 +364,8 @@ class TableToolbar extends React.Component {
           )}
           {options.filter && (
             <Popover
-              refExit={this.setActiveIcon.bind(null)}
+              refExit={filterPopoverExit}
+              hide={this.state.hideFilterPopover}
               classes={{ paper: classes.filterPaper, closeIcon: classes.filterCloseIcon }}
               trigger={
                 <Tooltip title={filterTable} disableFocusListener>
@@ -376,6 +387,8 @@ class TableToolbar extends React.Component {
                   filterData={filterData}
                   onFilterUpdate={filterUpdate}
                   onFilterReset={resetFilters}
+                  handleClose={closeFilterPopover}
+                  updateFilterByType={updateFilterByType}
                 />
               }
             />

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -1235,7 +1235,7 @@ describe('<MUIDataTable />', function() {
 
   it('should recalculate page when calling changeRowsPerPage method', () => {
     const mountWrapper = mount(
-      shallow(<MUIDataTable columns={columns} data={data} options={{ rowsPerPage: 2 }} />).get(0),
+      shallow(<MUIDataTable columns={columns} data={data} options={{ rowsPerPageOptions: [2,4,10,15,100], rowsPerPage: 2 }} />).get(0),
     );
     const instance = mountWrapper.instance();
 
@@ -1839,6 +1839,37 @@ describe('<MUIDataTable />', function() {
       ]);
       assert.deepEqual(JSON.stringify(filterData), expectedResult);
     });
+  });
+
+  it('should correctly filter data from filter popover menu', () => {
+
+    let filteredData = [];
+    const options = {
+      filter: true,
+      filterType: 'dropdown',
+      onFilterChange: (column, filterList, type, index, displayData) => {
+        filteredData = displayData;
+      }
+    };
+    
+    const fullWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+
+    fullWrapper
+      .find('[data-testid="Filter Table-iconButton"]')
+      .at(0)
+      .simulate('click');
+
+    fullWrapper
+      .find('[data-testid="filtertextfield-Name"] input')
+      .at(0)
+      .simulate('change', { target: { value: 'James' } })
+
+    fullWrapper.unmount();
+
+    assert.strictEqual(filteredData.length, 2);
+    assert.strictEqual(filteredData[0].data[0], 'James, Joe');
+    assert.strictEqual(filteredData[1].data[0], 'Houston, James');
+
   });
 
   describe('should correctly run comparator function', () => {

--- a/test/MUIDataTableFilter.test.js
+++ b/test/MUIDataTableFilter.test.js
@@ -262,6 +262,7 @@ describe('<TableFilter />', function() {
     const options = { filterType: 'checkbox', textLabels: getTextLabels() };
     const filterList = [[], [], [], []];
     const onFilterUpdate = spy();
+    const updateFilterByType = () => {};
 
     const shallowWrapper = shallow(
       <TableFilter
@@ -270,6 +271,7 @@ describe('<TableFilter />', function() {
         filterData={filterData}
         filterList={filterList}
         options={options}
+        updateFilterByType={updateFilterByType}
       />,
     ).dive();
     const instance = shallowWrapper.instance();
@@ -283,6 +285,7 @@ describe('<TableFilter />', function() {
     const options = { filterType: 'select', textLabels: getTextLabels() };
     const filterList = [[], [], [], []];
     const onFilterUpdate = spy();
+    const updateFilterByType = () => {};
 
     const shallowWrapper = shallow(
       <TableFilter
@@ -291,6 +294,7 @@ describe('<TableFilter />', function() {
         filterData={filterData}
         filterList={filterList}
         options={options}
+        updateFilterByType={updateFilterByType}
       />,
     ).dive();
     const instance = shallowWrapper.instance();
@@ -314,6 +318,7 @@ describe('<TableFilter />', function() {
     const options = { filterType: 'multiselect', textLabels: getTextLabels() };
     const filterList = [[], [], [], []];
     const onFilterUpdate = spy();
+    const updateFilterByType = () => {};
 
     const shallowWrapper = shallow(
       <TableFilter
@@ -322,6 +327,7 @@ describe('<TableFilter />', function() {
         filterData={filterData}
         filterList={filterList}
         options={options}
+        updateFilterByType={updateFilterByType}
       />,
     ).dive();
     const instance = shallowWrapper.instance();
@@ -346,6 +352,7 @@ describe('<TableFilter />', function() {
     const options = { filterType: 'textField', textLabels: getTextLabels() };
     const filterList = [[], [], [], []];
     const onFilterUpdate = spy();
+    const updateFilterByType = () => {};
 
     const shallowWrapper = shallow(
       <TableFilter
@@ -354,6 +361,7 @@ describe('<TableFilter />', function() {
         filterData={filterData}
         filterList={filterList}
         options={options}
+        updateFilterByType={updateFilterByType}
       />,
     ).dive();
     const instance = shallowWrapper.instance();


### PR DESCRIPTION
This will most likely be my last feature PR before v3 is released. This PR is an update to https://github.com/gregnb/mui-datatables/pull/1093

The table currently has a serverSideFilterList option to help with filtering for serverSide tables. The idea is to delay adding filter chips until a user "applies" the filters. This feature has the following problems:

* It requires the user manage an external filterList.
* Having a serverSideFilterList and a client-side filterList is not DRY.
* It does not help with filtering for tables with large data sets.

This PR offers up an alternative solution that doesn't have the above problems. It does the following:

* It adds an option called "confirmFilters". When true, filters won't be applied to the table unless they are "confirmed".
* Confirming happens via a callback function passed to the customFilterDialogFooter option.

This solution requires less overhead on the developer's part and works for both server-side tables and large data set tables (both examples have been updated to use the new option). Additionally, it's more future-proof than the serverSideFilterList option since it works with the internal filterList rather than creating another filterList that has to be looked after.

The serverSideFilterList option gets deprecated in this PR, but will still work, so it doesn't require any immediately code re-workings.