### PR TITLE
Minor bug fix for header checkbox when selectToolbarPlacement = 'none' or 'above'

### DIFF
--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -55,7 +55,7 @@ class TableHead extends React.Component {
     // When the disableToolbarSelect option is true, there can be
     // selected items that aren't visible, so we need to be more
     // precise when determining if the head checkbox should be checked.
-    if (options.disableToolbarSelect === true || (options.selectToolbarPlacement === 'none' || options.selectToolbarPlacement === 'above')) {
+    if (options.disableToolbarSelect === true || options.selectToolbarPlacement === 'none' || options.selectToolbarPlacement === 'above') {
       if (isChecked) {
         for (let ii = 0; ii < data.length; ii++) {
           if (!selectedRows.lookup[data[ii].dataIndex]) {

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -50,12 +50,12 @@ class TableHead extends React.Component {
 
     const numSelected = (selectedRows && selectedRows.data.length) || 0;
     let isIndeterminate = numSelected > 0 && numSelected < count;
-    let isChecked = numSelected > 0 && numSelected === count;
+    let isChecked = numSelected > 0 && numSelected >= count;
 
     // When the disableToolbarSelect option is true, there can be
     // selected items that aren't visible, so we need to be more
     // precise when determining if the head checkbox should be checked.
-    if (options.disableToolbarSelect === true) {
+    if (options.disableToolbarSelect === true || (options.selectToolbarPlacement === 'none' || options.selectToolbarPlacement === 'above')) {
       if (isChecked) {
         for (let ii = 0; ii < data.length; ii++) {
           if (!selectedRows.lookup[data[ii].dataIndex]) {


### PR DESCRIPTION
This is an edge case that occurs for the selectToolbarPlacement option. It's accounted for when using the disableToolbarSelect option. To re-create:

* Set selectToolbarPlacement to "none" or "above".
* Select all rows.
* Do a search so that only a few rows will show up.
* The header checkbox won't be checked.

This PR will make it so the checkbox stays checked. Workaround is to use disableToolbarSelect option. 