### PR TITLE
Bug fix for #1280 / Fix issues with resizableColumns

### DIFF
--- a/examples/resizable-columns/index.js
+++ b/examples/resizable-columns/index.js
@@ -1,70 +1,67 @@
-import React from "react";
+import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src/";
 
-class Example extends React.Component {
+import FormControl from '@material-ui/core/FormControl';
+import TextField from '@material-ui/core/TextField';
 
-  constructor(props) {
-    super(props);
+function Example(props) {
 
-    this.state = { counter: 1 };
-  }
+  const [marginLeft, setMarginLeft] = useState(200);
 
-  // We update an arbitrary value here to test table resizing on state updates
-  update = () => {
-    let { counter } = this.state;
-    counter += 1;
-
-    this.setState({ counter });
+  const [counter, setCounter] = useState(1);
+  const incrCount = () => { // We update an arbitrary value here to test table resizing on state updates
+    setCounter(counter + 1);
   };
 
-  render() {
-    const { counter } = this.state;
+  const columns = [
+    {
+      name: "Counter",
+      options: {
+        empty: true,
+        customBodyRender: value => <button onClick={incrCount}>+</button>
+      }
+    },
+    {
+      name: "Name",
+      options: {
+        sort: false,
+        hint: "?"
+      }
+    },
+    {
+      name: "Title",
+      options: {
+        hint: "?"
+      }
+    },
+    "Location"
+  ];
 
-    const columns = [
-      {
-        name: "Counter",
-        options: {
-          empty: true,
-          customBodyRender: value => <button onClick={this.update}>+</button>
-        }
-      },
-      {
-        name: "Name",
-        options: {
-          sort: false,
-          hint: "?"
-        }
-      },
-      {
-        name: "Title",
-        options: {
-          hint: "?"
-        }
-      },
-      "Location"
-    ];
+  const data = [
+    ["Gabby George", "Business Analyst", "Minneapolis"],
+    ["Aiden Lloyd", "Business Consultant", "Dallas"],
+    ["Jaden Collins", "Attorney", "Santa Ana"],
+    ["Franky Rees", "Business Analyst", "St. Petersburg"],
+    ["Aaren Rose", null, "Toledo"]
+  ];
 
-    const data = [
-      ["Gabby George", "Business Analyst", "Minneapolis"],
-      ["Aiden Lloyd", "Business Consultant", "Dallas"],
-      ["Jaden Collins", "Attorney", "Santa Ana"],
-      ["Franky Rees", "Business Analyst", "St. Petersburg"],
-      ["Aaren Rose", null, "Toledo"]
-    ];
+  const options = {
+    filter: true,
+    filterType: 'dropdown',
+    resizableColumns: true
+  };
 
-
-    const options = {
-      filter: true,
-      filterType: 'dropdown',
-      resizableColumns: true
-    };
-
-    return (
-      <MUIDataTable title={"ACME Employee list" + " [" + counter + "]"} data={data} columns={columns} options={options} />
-    );
-
-  }
+  return (
+    <>
+      <FormControl>
+        <TextField label="Left Margin" type="number" value={marginLeft} onChange={(e) => setMarginLeft(e.target.value)} />
+      </FormControl>
+      <div style={{marginLeft: marginLeft + 'px'}}>
+        <MUIDataTable title={"ACME Employee list" + " [" + counter + "]"} data={data} columns={columns} options={options} />
+      </div>
+    </>
+  );
 }
 
 export default Example;

--- a/examples/resizable-columns/index.js
+++ b/examples/resizable-columns/index.js
@@ -7,7 +7,7 @@ import TextField from '@material-ui/core/TextField';
 
 function Example(props) {
 
-  const [marginLeft, setMarginLeft] = useState(200);
+  const [marginLeft, setMarginLeft] = useState(10);
 
   const [counter, setCounter] = useState(1);
   const incrCount = () => { // We update an arbitrary value here to test table resizing on state updates

--- a/examples/resizable-columns/index.js
+++ b/examples/resizable-columns/index.js
@@ -30,7 +30,7 @@ function Example(props) {
       }
     },
     {
-      name: "Title",
+      name: "Business Title",
       options: {
         hint: "?"
       }
@@ -49,7 +49,7 @@ function Example(props) {
   const options = {
     filter: true,
     filterType: 'dropdown',
-    resizableColumns: true
+    resizableColumns: true,
   };
 
   return (

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -209,7 +209,7 @@ class MUIDataTable extends React.Component {
       tableBodyHeight: PropTypes.string,
       tableBodyMaxHeight: PropTypes.string,
       renderExpandableRow: PropTypes.func,
-      resizableColumns: PropTypes.bool,
+      resizableColumns: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
       responsive: PropTypes.oneOf(['standard', 'vertical', 'simple']),
       rowHover: PropTypes.bool,
       rowsExpanded: PropTypes.array,
@@ -321,7 +321,7 @@ class MUIDataTable extends React.Component {
       this.setState({ page: 0 });
     }
 
-    if (this.options.resizableColumns) {
+    if (this.options.resizableColumns === true || (this.options.resizableColumns && this.options.resizableColumns.enabled) ) {
       this.setHeadResizeable(this.headCellRefs, this.tableRef);
       this.updateDividers();
     }
@@ -1747,7 +1747,7 @@ class MUIDataTable extends React.Component {
           columnNames={columnNames}
         />
         <div style={{ position: 'relative', ...tableHeightVal }} className={responsiveClass}>
-          {this.options.resizableColumns && (
+          { (this.options.resizableColumns === true || (this.options.resizableColumns && this.options.resizableColumns.enabled)) && (
             <TableResizeComponent
               key={rowCount}
               updateDividers={fn => (this.updateDividers = fn)}

--- a/test/TableResize.test.js
+++ b/test/TableResize.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { spy, stub } from 'sinon';
+import { mount, shallow } from 'enzyme';
+import { assert, expect, should } from 'chai';
+import TableResize from '../src/components/TableResize';
+import MUIDataTable from '../src/MUIDataTable';
+
+describe('<TableResize />', function() {
+  let options;
+
+  before(() => {
+    options = {
+      resizableColumns: true,
+      tableBodyHeight: '500px'
+    };
+  });
+
+  it('should render a table resize component', () => {
+    const updateDividers = spy();
+    const setResizeable = spy();
+
+    const mountWrapper = mount(<TableResize options={options} updateDividers={updateDividers} setResizeable={setResizeable} />);
+
+    const actualResult = mountWrapper.find(TableResize);
+    assert.strictEqual(actualResult.length, 1);
+
+    assert.strictEqual(updateDividers.callCount, 1);
+    assert.strictEqual(setResizeable.callCount, 1);
+  });
+
+  it('should create a coordinate map for each column', () => {
+    const columns = ["Name", "Age", "Location", "Phone"];
+    const data = [
+      ["Joe", 26, "Chile", "555-5555"]
+    ];
+
+    const shallowWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+
+    var state = shallowWrapper.find(TableResize).childAt(0).state();
+
+    var colCoordCount = 0;
+    for (let prop in state.resizeCoords) {
+      colCoordCount++;
+    }
+
+    assert.strictEqual(colCoordCount, 4);
+  });
+
+});

--- a/test/setup-mocha-env.js
+++ b/test/setup-mocha-env.js
@@ -56,6 +56,8 @@ function setupDom() {
   global.getComputedStyle = global.window.getComputedStyle;
   global.HTMLInputElement = global.window.HTMLInputElement;
   global.Element = global.window.Element;
+  global.Event = global.window.Event;
+  global.dispatchEvent = global.window.dispatchEvent;
 
   Object.defineProperty(global.window.URL, 'createObjectURL', { value: () => {} });
   global.Blob = () => '';


### PR DESCRIPTION
The resizableColumns feature currently doesn't work when there is left margin on the container for the table (see https://github.com/gregnb/mui-datatables/issues/1280).

This PR makes some adjustments so that the resizableColumns work with leftMargin. The PR can be viewed below: (see the "Resizable Columns" example)

https://codesandbox.io/s/github/gregnb/mui-datatables/tree/resizeLeftMargin