### PR TITLE
Missing link to Custom Components in README's ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Version 3 has been released! You can read about the [updates here](https://githu
 * [Customize Columns](#customize-columns)
 * [Plug-ins](#plug-ins)
 * [Customize Styling](#customize-styling)
+* [Custom Components](#custom-components)
 * [Remote Data](#remote-data)
 * [Localization](#localization)
 * [Contributing](#contributing)


### PR DESCRIPTION
Custom components were introduced per the following PR/commit but lack the add to the Table of Contents:
- https://github.com/gregnb/mui-datatables/pull/1167
- https://github.com/gregnb/mui-datatables/pull/1300/commits/12c08a575dc327f7766b2982267d170d756893e0