### PR TITLE
Added setFilterChipProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The component accepts the following props:
 |**`selectableRowsOnClick`**|boolean|false|Enable/disable select toggle when row is clicked. When False, only checkbox will trigger this action.
 |**`selectToolbarPlacement`**|string|'replace'|Controls the visibility of the Select Toolbar, options are 'replace' (select toolbar replaces default toolbar when a row is selected), 'above' (select toolbar will appear above default toolbar when a row is selected) and 'none' (select toolbar will never appear)
 |**`serverSide`**|boolean|false|Enable remote data source.
+|**`setFilterChipProps`**|function||Is called for each filter chip and allows you to place custom props on a filter chip. `function(colIndex: number, colName: string, filterValue: string) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-filter/index.js)
 |**`setRowProps`**|function||Is called for each row and allows you to return custom props for this row based on its data. `function(row: array, dataIndex: number, rowIndex: number) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`setTableProps`**|function||Is called for the table and allows you to return custom props for the table based on its data. `function() => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`sort`**|boolean|true|Enable/disable sort on all columns.

--- a/examples/customize-filter/index.js
+++ b/examples/customize-filter/index.js
@@ -235,6 +235,14 @@ class Example extends React.Component {
       filter: true,
       filterType: 'multiselect',
       responsive: 'standard',
+      setFilterChipProps: (colIndex, colName, data) => {
+        //console.log(colIndex, colName, data);
+        return {
+          color: 'primary',
+          variant: 'outlined',
+          className: 'testClass123',
+        };
+      }
     };
     
     return (

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -227,6 +227,7 @@ class MUIDataTable extends React.Component {
       searchOpen: PropTypes.bool,
       searchPlaceholder: PropTypes.string,
       searchText: PropTypes.string,
+      setFilterChipProps: PropTypes.func,
       setRowProps: PropTypes.func,
       selectToolbarPlacement: PropTypes.oneOfType([
         PropTypes.bool,
@@ -1756,7 +1757,7 @@ class MUIDataTable extends React.Component {
       tableHeightVal.height = this.options.tableBodyHeight;
     }
 
-    let tableProps = this.options.setTableProps ? (this.options.setTableProps() || {}) : {};
+    let tableProps = this.options.setTableProps ? this.options.setTableProps() || {} : {};
     let tableClassNames = classnames(classes.tableRoot, tableProps.className);
     delete tableProps.className; // remove className from props to avoid the className being applied twice
 

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -244,7 +244,7 @@ class TableBody extends React.Component {
 
             let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;
             let isRowSelectable = this.isRowSelectable(dataIndex);
-            let bodyClasses = options.setRowProps ? (options.setRowProps(row, dataIndex, rowIndex) || {}) : {};
+            let bodyClasses = options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) || {} : {};
 
             const processedRow = this.processRow(row, columnOrder);
 
@@ -293,7 +293,7 @@ class TableBody extends React.Component {
                       columns[column.index].display === 'true' && (
                         <TableBodyCell
                           {...(columns[column.index].setCellProps
-                            ? (columns[column.index].setCellProps(column.value, dataIndex, column.index) || {})
+                            ? columns[column.index].setCellProps(column.value, dataIndex, column.index) || {}
                             : {})}
                           data-testid={`MuiDataTableBodyCell-${column.index}-${rowIndex}`}
                           dataIndex={dataIndex}

--- a/src/components/TableFilterList.js
+++ b/src/components/TableFilterList.js
@@ -36,7 +36,7 @@ const TableFilterList = ({
     if (Array.isArray(removedFilter) && removedFilter.length === 0) {
       removedFilter = filterList[index];
     }
-
+    
     filterUpdate(index, filterValue, columnName, filterType, null, filterList => {
       if (options.onFilterChipClose) {
         options.onFilterChipClose(index, removedFilter, filterList);
@@ -63,6 +63,7 @@ const TableFilterList = ({
         index={index}
         data={item}
         columnNames={columnNames}
+        filterProps={options.setFilterChipProps ? options.setFilterChipProps(index, columnNames[index].name, item[customFilterItemIndex] || []) : {}}
       />
     );
   };
@@ -77,6 +78,7 @@ const TableFilterList = ({
       index={index}
       data={data}
       columnNames={columnNames}
+      filterProps={options.setFilterChipProps ? options.setFilterChipProps(index, columnNames[index].name, data) : {}}
     />
   );
 

--- a/src/components/TableFilterListItem.js
+++ b/src/components/TableFilterListItem.js
@@ -1,9 +1,14 @@
 import Chip from '@material-ui/core/Chip';
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 
-const TableFilterListItem = ({ label, onDelete, className }) => {
-  return <Chip label={label} onDelete={onDelete} className={className} />;
+const TableFilterListItem = ({ label, onDelete, className, filterProps }) => {
+  filterProps = filterProps || {};
+  if (filterProps.className) {
+    className = classnames(className, filterProps.className);
+  }
+  return <Chip label={label} onDelete={onDelete} className={className} {...filterProps} />;
 };
 
 TableFilterListItem.propTypes = {

--- a/test/MUIDataTableFilterList.test.js
+++ b/test/MUIDataTableFilterList.test.js
@@ -1,0 +1,154 @@
+import Checkbox from '@material-ui/core/Checkbox';
+import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import { assert } from 'chai';
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { spy } from 'sinon';
+import TableFilterList from '../src/components/TableFilterList';
+import getTextLabels from '../src/textLabels';
+import Chip from '@material-ui/core/Chip';
+
+describe('<TableFilterList />', function() {
+  let data;
+  let columns;
+  let filterData;
+
+  beforeEach(() => {
+    columns = [
+      { name: 'name', label: 'Name', display: true, sort: true, filter: true, sortDirection: 'desc' },
+      { name: 'company', label: 'Company', display: true, sort: true, filter: true, sortDirection: 'desc' },
+      { name: 'city', label: 'City Label', display: true, sort: true, filter: true, sortDirection: 'desc' },
+      { name: 'state', label: 'State', display: true, sort: true, filter: true, sortDirection: 'desc' },
+    ];
+
+    data = [
+      ['Joe James', 'Test Corp', 'Yonkers', 'NY'],
+      ['John Walsh', 'Test Corp', 'Hartford', 'CT'],
+      ['Bob Herm', 'Test Corp', 'Tampa', 'FL'],
+      ['James Houston', 'Test Corp', 'Dallas', 'TX'],
+    ];
+
+    filterData = [
+      ['Joe James', 'John Walsh', 'Bob Herm', 'James Houston'],
+      ['Test Corp'],
+      ['Yonkers', 'Hartford', 'Tampa', 'Dallas'],
+      ['NY', 'CT', 'FL', 'TX'],
+    ];
+  });
+
+  it('should render a filter chip for a filter', () => {
+    const options = { textLabels: getTextLabels() };
+    const filterList = [['Joe James'], [], [], []];
+    const filterUpdate = spy();
+    const columnNames = columns.map(column => ({
+      name: column.name,
+      filterType: column.filterType || options.filterType,
+    }));
+    const wrapper = mount(
+      <TableFilterList 
+          options={options}
+          filterListRenderers={columns.map(c => {
+            if (c.customFilterListOptions && c.customFilterListOptions.render) return c.customFilterListOptions.render;
+            if (c.customFilterListRender) return c.customFilterListRender;
+            return f => f;
+          })}
+          customFilterListUpdate={columns.map(c => {
+            return c.customFilterListOptions && c.customFilterListOptions.update
+              ? c.customFilterListOptions.update
+              : null;
+          })}
+          filterList={filterList}
+          filterUpdate={filterUpdate}
+          columnNames={columnNames}
+       />,
+    );
+
+    let numChips = wrapper
+      .find(Chip).length;
+
+    assert.strictEqual(numChips, 1);
+
+    wrapper.unmount();
+  });
+
+  it('should place a class onto the filter chip', () => {
+    const options = { 
+      textLabels: getTextLabels(),
+      setFilterChipProps: (a,b,c) => {
+        console.log(a,b,c);
+        return {
+          className: 'testClass123'
+        };
+      }
+    };
+    const filterList = [['Joe James'], [], [], []];
+    const filterUpdate = spy();
+    const columnNames = columns.map(column => ({
+      name: column.name,
+      filterType: column.filterType || options.filterType,
+    }));
+    const wrapper = mount(
+      <TableFilterList 
+          options={options}
+          filterListRenderers={columns.map(c => {
+            if (c.customFilterListOptions && c.customFilterListOptions.render) return c.customFilterListOptions.render;
+            if (c.customFilterListRender) return c.customFilterListRender;
+            return f => f;
+          })}
+          customFilterListUpdate={columns.map(c => {
+            return c.customFilterListOptions && c.customFilterListOptions.update
+              ? c.customFilterListOptions.update
+              : null;
+          })}
+          filterList={filterList}
+          filterUpdate={filterUpdate}
+          columnNames={columnNames}
+       />,
+    );
+
+    let numChips = wrapper.find('.testClass123').hostNodes().length;
+    assert.strictEqual(numChips, 1);
+  });
+
+  it('should remove a filter chip and call onFilterChipClose when its X icon is clicked', () => {
+    const options = { 
+      textLabels: getTextLabels(),
+      onFilterChipClose: spy()
+    };
+    const filterList = [['Joe James'], [], [], []];
+    const filterUpdateCall = spy();
+    const filterUpdate = (index, filterValue, columnName, filterType, tmp, next) => {
+      filterUpdateCall();
+      next();
+    };
+    const columnNames = columns.map(column => ({
+      name: column.name,
+      filterType: column.filterType || options.filterType,
+    }));
+    const wrapper = mount(
+      <TableFilterList 
+          options={options}
+          filterListRenderers={columns.map(c => {
+            if (c.customFilterListOptions && c.customFilterListOptions.render) return c.customFilterListOptions.render;
+            if (c.customFilterListRender) return c.customFilterListRender;
+            return f => f;
+          })}
+          customFilterListUpdate={columns.map(c => {
+            return c.customFilterListOptions && c.customFilterListOptions.update
+              ? c.customFilterListOptions.update
+              : null;
+          })}
+          filterList={filterList}
+          filterUpdate={filterUpdate}
+          columnNames={columnNames}
+       />,
+    );
+
+    wrapper.find('.MuiChip-deleteIcon').at(0).simulate('click');
+
+    assert.strictEqual(filterUpdateCall.callCount, 1); // ensures the call to update the filters was made
+    assert.strictEqual(options.onFilterChipClose.callCount, 1); // ensures the call to onFilterChipClose occurred
+  });
+});

--- a/test/MUIDataTableHead.test.js
+++ b/test/MUIDataTableHead.test.js
@@ -34,7 +34,6 @@ describe('<TableHead />', function() {
   it('should render a table head', () => {
     const options = {};
     const toggleSort = () => {};
-    console.dir(columns);
     const mountWrapper = mount(
       <DndProvider backend={HTML5Backend}>
         <TableHead
@@ -46,7 +45,6 @@ describe('<TableHead />', function() {
         />
       </DndProvider>,
     );
-    console.log(mountWrapper.html());
     const actualResult = mountWrapper.find(TableHeadCell);
     assert.strictEqual(actualResult.length, 4);
   });


### PR DESCRIPTION
New option that allows you to add props to the Filter Chip component. Works identically to the other setXProps methods. Example:

      setFilterChipProps: (colIndex, colName, data) => {
        //console.log(colIndex, colName, data);
        return {
          color: 'primary',
          variant: 'outlined',
          className: 'testClass123',
        };
      }

Useful for easily customizing to a filter chip. This can already be done through the custom component feature, but doing it that way is a bit of work. Using setFilterChipProps would make customization a lot easier.