### PR TITLE
Refactored out unsafe_componentWillMount

### DIFF
--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -579,7 +579,7 @@ describe('<MUIDataTable />', function() {
   });
 
   it('should not re-build internal table data and displayData structure with no prop change to data or columns', () => {
-    const initializeTableSpy = spy(MUIDataTable.Naked.prototype, 'initializeTable');
+    const setTableDataSpy = spy(MUIDataTable.Naked.prototype, 'setTableData');
     const mountWrapper = mount(shallow(<MUIDataTable columns={columns} data={data} />).get(0));
 
     let state = mountWrapper.state();
@@ -592,7 +592,7 @@ describe('<MUIDataTable />', function() {
     state = mountWrapper.state();
 
     assert.deepEqual(JSON.stringify(state.displayData), displayData);
-    assert.deepEqual(initializeTableSpy.callCount, 1);
+    assert.deepEqual(setTableDataSpy.callCount, 1);
   });
 
   it('should add custom props to table if setTableProps provided', () => {
@@ -793,7 +793,7 @@ describe('<MUIDataTable />', function() {
   it('should apply columns prop change for filterList', () => {
     const mountShallowWrapper = mount(shallow(<MUIDataTable columns={columns} data={data} />).get(0));
     const instance = mountShallowWrapper.instance();
-    instance.initializeTable(mountShallowWrapper.props());
+
     // now use updated columns props
     const newColumns = cloneDeep(columns);
     newColumns[0].options.filterList = ['Joe James'];
@@ -1242,11 +1242,12 @@ describe('<MUIDataTable />', function() {
   });
 
   it('should get displayable data when calling getDisplayData method', () => {
-    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
+    const wrapper = shallow(<MUIDataTable columns={columns} data={data} />);
+    const shallowWrapper = wrapper.dive();
     const instance = shallowWrapper.instance();
     const state = shallowWrapper.state();
-
-    const actualResult = instance.getDisplayData(columns, tableData, state.filterList, '');
+    
+    const actualResult = instance.getDisplayData(columns, tableData, state.filterList, '', null, wrapper.props());
     assert.deepEqual(JSON.stringify(actualResult), displayData);
   });
 


### PR DESCRIPTION
The table currently uses the method unsafe_componentWillMount in the main component. React is removing this lifecycle method in version 17 and it currently gives a warning message to developers using strict mode (https://github.com/gregnb/mui-datatables/issues/1261). The method is deemed unsafe because it can lead to memory leaks if not used properly.

React recommends using the constructor is initialize state or componentDidMount for initialization that requires DOM nodes. Only the former is relevant to mui-datatables, so the code has been refactored to use the constructor.