### PR TITLE
Added support for custom sort function for columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The component accepts the following props:
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`customSearchRender `**|function||Render a custom table search. `customSearchRender(searchText: string, handleSearch, hideSearch, options) => React Component`
-|**`customSort`**|function||Override default sorting with custom function. If you just need to override the sorting for a particular column, see the sortFn in the [column options](https://github.com/gregnb/mui-datatables#column-options). `function(data: array, colIndex: number, order: string) => array` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js)
+|**`customSort`**|function||Override default sorting with custom function. If you just need to override the sorting for a particular column, see the sortCompare method in the [column options](https://github.com/gregnb/mui-datatables#column-options). `function(data: array, colIndex: number, order: string) => array` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js)
 |**`customTableBodyFooterRender`**|function||Render a footer under the table body but above the table's standard footer. This is useful for creating footers for individual columns. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
@@ -282,7 +282,7 @@ const columns = [
 |**`setCellHeaderProps`**|function||Is called for each header cell and allows you to return custom props for the header cell based on its data. `function(columnMeta: object) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`setCellProps`**|function||Is called for each cell and allows to you return custom props for this cell based on its data. `function(cellValue: string, rowIndex: number, columnIndex: number) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`sort`**|boolean|true|Enable/disable sorting on column.
-|**`sortFn`**|function||Custom sort function for the column. If this method and options.customSort are both defined, this method will take precedence. `(order) => ({data: val1}, {data: val2}) => number` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js). Note: currently doesn't work with table `customSort`
+|**`sortCompare`**|function||Custom sort function for the column. Takes in an order string and returns a function that compares the two column values. If this method and options.customSort are both defined, this method will take precedence. `(order) => ({data: val1}, {data: val2}) => number` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js). Note: currently doesn't work with table `customSort`
 |**`viewColumns`**|boolean|true|Allow user to toggle column visibility through 'View Column' list.
 
 `customHeadRender` is called with these arguments:

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ const columns = [
 |**`setCellHeaderProps`**|function||Is called for each header cell and allows you to return custom props for the header cell based on its data. `function(columnMeta: object) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`setCellProps`**|function||Is called for each cell and allows to you return custom props for this cell based on its data. `function(cellValue: string, rowIndex: number, columnIndex: number) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`sort`**|boolean|true|Enable/disable sorting on column.
+|**`sortFn`**|function||Custom sort function for that column: `(order) => ({data: val1}, {data: val2}) => number` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js). Note: currently doesn't work with table `customSort`
 |**`viewColumns`**|boolean|true|Allow user to toggle column visibility through 'View Column' list.
 
 `customHeadRender` is called with these arguments:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The component accepts the following props:
 |**`customRowRender `**|function||Override default row rendering with custom function. `customRowRender(data, dataIndex, rowIndex) => React Component`
 |**`customSearch `**|function||Override default search with custom function. `customSearch(searchQuery: string, currentRow: array, columns: array) => boolean`
 |**`customSearchRender `**|function||Render a custom table search. `customSearchRender(searchText: string, handleSearch, hideSearch, options) => React Component`
-|**`customSort`**|function||Override default sorting with custom function. `function(data: array, colIndex: number, order: string) => array`
+|**`customSort`**|function||Override default sorting with custom function. If you just need to override the sorting for a particular column, see the sortFn in the [column options](https://github.com/gregnb/mui-datatables#column-options). `function(data: array, colIndex: number, order: string) => array` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-sorting/index.js)
 |**`customTableBodyFooterRender`**|function||Render a footer under the table body but above the table's standard footer. This is useful for creating footers for individual columns. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-footer/index.js)
 |**`customToolbar`**|function||Render a custom toolbar
 |**`customToolbarSelect`**|function||Render a custom selected rows toolbar. `function(selectedRows, displayData, setSelectedRows) => void`
@@ -282,7 +282,7 @@ const columns = [
 |**`setCellHeaderProps`**|function||Is called for each header cell and allows you to return custom props for the header cell based on its data. `function(columnMeta: object) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`setCellProps`**|function||Is called for each cell and allows to you return custom props for this cell based on its data. `function(cellValue: string, rowIndex: number, columnIndex: number) => object` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-styling/index.js)
 |**`sort`**|boolean|true|Enable/disable sorting on column.
-|**`sortFn`**|function||Custom sort function for that column: `(order) => ({data: val1}, {data: val2}) => number` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js). Note: currently doesn't work with table `customSort`
+|**`sortFn`**|function||Custom sort function for the column. If this method and options.customSort are both defined, this method will take precedence. `(order) => ({data: val1}, {data: val2}) => number` [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/column-sort/index.js). Note: currently doesn't work with table `customSort`
 |**`viewColumns`**|boolean|true|Allow user to toggle column visibility through 'View Column' list.
 
 `customHeadRender` is called with these arguments:

--- a/examples/column-sort/index.js
+++ b/examples/column-sort/index.js
@@ -19,12 +19,12 @@ class Example extends React.Component {
         options: {
           /*
             In this case, age is a string, but we want to compare it as if it was a number.
-            If you comment out the sortFn method, you'll see how sorting as a string
+            If you comment out the sortCompare method, you'll see how sorting as a string
             is different than sorting as a number. Typically an age field would be a number
-            so we wouldn't need to write a function like this. But the sortFn is available
+            so we wouldn't need to write a function like this. But the sortCompare is available
             if you run into a situation like this.
           */
-          sortFn: (order) => {
+          sortCompare: (order) => {
             return (obj1, obj2) => {
               console.log(order);
               var val1 = parseInt(obj1.data, 10);
@@ -37,7 +37,7 @@ class Example extends React.Component {
       {
         name: "Hobbies",
         options: {
-          sortFn: (order) =>
+          sortCompare: (order) =>
             ({ data: hobbyList1 }, { data: hobbyList2 }) =>
               (hobbyList1.length - hobbyList2.length) * (order === 'asc' ? 1 : -1),
           hint: 'Sort by amount of hobbies',

--- a/examples/column-sort/index.js
+++ b/examples/column-sort/index.js
@@ -1,0 +1,64 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { Chip } from "@material-ui/core";
+import MUIDataTable from "../../src/";
+
+class Example extends React.Component {
+
+  render() {
+
+    const columns = [
+      {
+        name: "Name",
+      },
+      {
+        name: "Title",
+      },
+      {
+        name: "Age",
+      },
+      {
+        name: "Hobbies",
+        options: {
+          sortFn: (order) =>
+            ({ data: hobbyList1 }, { data: hobbyList2 }) =>
+              (hobbyList1.length - hobbyList2.length) * (order === 'asc' ? 1 : -1),
+          hint: 'Sort by amount of hobbies',
+          customBodyRender: hobbies => hobbies.map((hobby, index) => <Chip key={index} label={hobby} />)
+        }
+      }
+    ];
+    const data = [
+      ["Gabby George", "Business Analyst", 30, ["Sports"]],
+      ["Business Analyst", "Business Consultant", 55, ["Water Polo"]],
+      ["Jaden Collins", "Attorney", 27, ["Sports", "TV"]],
+      ["Franky Rees", "Business Analyst", 22, ["Baking", "Hiking"]],
+      ["Aaren Rose", "Business Consultant", 28, ["Hiking"]],
+      ["Blake Duncan", "Business Management Analyst", 65, ["Sprots", "Cooking", "Baking"]],
+      ["Frankie Parry", "Agency Legal Counsel", 71, []],
+      ["Lane Wilson", "Commercial Specialist", 19, ["Cooking"]],
+      ["Robin Duncan", "Business Analyst", 20, ["Acting"]],
+      ["Mel Brooks", "Business Consultant", 37, ["Puzzles", "Sewing"]],
+      ["Harper White", "Attorney", 52, ["Fising"]],
+      ["Kris Humphrey", "Agency Legal Counsel", 30, []],
+      ["Frankie Long", "Industrial Analyst", 31, []],
+      ["Brynn Robbins", "Business Analyst", 22, ["Fishing", "Hiking"]],
+      ["Justice Mann", "Business Consultant", 24, ["Footbal"]],
+      ["Addison Navarro", "Business Management Analyst", 50, ["Photography"]]
+    ];
+
+    const options = {
+      filter: true,
+      filterType: 'dropdown',
+      responsive: 'stacked',
+      rowsPerPage: 50,
+    };
+
+    return (
+      <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
+    );
+
+  }
+}
+
+export default Example;

--- a/examples/column-sort/index.js
+++ b/examples/column-sort/index.js
@@ -16,6 +16,23 @@ class Example extends React.Component {
       },
       {
         name: "Age",
+        options: {
+          /*
+            In this case, age is a string, but we want to compare it as if it was a number.
+            If you comment out the sortFn method, you'll see how sorting as a string
+            is different than sorting as a number. Typically an age field would be a number
+            so we wouldn't need to write a function like this. But the sortFn is available
+            if you run into a situation like this.
+          */
+          sortFn: (order) => {
+            return (obj1, obj2) => {
+              console.log(order);
+              var val1 = parseInt(obj1.data, 10);
+              var val2 = parseInt(obj2.data, 10);
+              return (val1 - val2) * (order === 'asc' ? 1 : -1);
+            };
+          }
+        }
       },
       {
         name: "Hobbies",
@@ -29,29 +46,32 @@ class Example extends React.Component {
       }
     ];
     const data = [
-      ["Gabby George", "Business Analyst", 30, ["Sports"]],
-      ["Business Analyst", "Business Consultant", 55, ["Water Polo"]],
-      ["Jaden Collins", "Attorney", 27, ["Sports", "TV"]],
-      ["Franky Rees", "Business Analyst", 22, ["Baking", "Hiking"]],
-      ["Aaren Rose", "Business Consultant", 28, ["Hiking"]],
-      ["Blake Duncan", "Business Management Analyst", 65, ["Sprots", "Cooking", "Baking"]],
-      ["Frankie Parry", "Agency Legal Counsel", 71, []],
-      ["Lane Wilson", "Commercial Specialist", 19, ["Cooking"]],
-      ["Robin Duncan", "Business Analyst", 20, ["Acting"]],
-      ["Mel Brooks", "Business Consultant", 37, ["Puzzles", "Sewing"]],
-      ["Harper White", "Attorney", 52, ["Fising"]],
-      ["Kris Humphrey", "Agency Legal Counsel", 30, []],
-      ["Frankie Long", "Industrial Analyst", 31, []],
-      ["Brynn Robbins", "Business Analyst", 22, ["Fishing", "Hiking"]],
-      ["Justice Mann", "Business Consultant", 24, ["Footbal"]],
-      ["Addison Navarro", "Business Management Analyst", 50, ["Photography"]]
+      ["Gabby George", "Business Analyst", "30", ["Sports"]],
+      ["Business Analyst", "Business Consultant", "55", ["Water Polo"]],
+      ["Jaden Collins", "Attorney", "27", ["Sports", "TV"]],
+      ["Franky Rees", "Business Analyst", "22", ["Baking", "Hiking"]],
+      ["Aaren Rose", "Business Consultant", "28", ["Hiking"]],
+      ["Blake Duncan", "Business Management Analyst", "65", ["Sprots", "Cooking", "Baking"]],
+      ["Frankie Parry", "Agency Legal Counsel", "71", []],
+      ["Lane Wilson", "Commercial Specialist", "19", ["Cooking"]],
+      ["Robin Duncan", "Business Analyst", "20", ["Acting"]],
+      ["Mel Brooks", "Business Consultant", "37", ["Puzzles", "Sewing"]],
+      ["Harper White", "Attorney", "52", ["Fising"]],
+      ["Kris Humphrey", "Agency Legal Counsel", "30", []],
+      ["Frankie Long", "Industrial Analyst", "31", []],
+      ["Brynn Robbins", "Business Analyst", "22", ["Fishing", "Hiking"]],
+      ["Justice Mann", "Business Consultant", "24", ["Footbal"]],
+      ["JoJo", "Business Consultant", "2", ["Sleeping"]],
+      ["Bobby Smith", "Business Consultant", "3", []],
+      ["Addison Navarro", "Business Management Analyst", "50", ["Photography"]]
     ];
 
     const options = {
       filter: true,
       filterType: 'dropdown',
-      responsive: 'stacked',
+      responsive: 'vertical',
       rowsPerPage: 50,
+      rowsPerPageOptions: [50],
     };
 
     return (

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -1,6 +1,7 @@
 import ArrayValueColumns from './array-value-columns';
 import ColumnFilters from './column-filters';
 import ColumnOptionsUpdate from './column-options-update';
+import ColumnSort from "./column-sort";
 import Component from './component';
 import CSVExport from './csv-export';
 import CustomActionColumns from './custom-action-columns';
@@ -41,6 +42,7 @@ export default {
   'Array Value Columns': ArrayValueColumns,
   'Column Filters': ColumnFilters,
   'Column Option Update': ColumnOptionsUpdate,
+  'Column Sort': ColumnSort,
   Component: Component,
   'CSV Export': CSVExport,
   'Custom Action Columns': CustomActionColumns,

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -580,6 +580,7 @@ class MUIDataTable extends React.Component {
         searchable: true,
         download: true,
         viewColumns: true,
+        sortFn: null,
       };
 
       columnOrder.push(colIndex);
@@ -870,7 +871,7 @@ class MUIDataTable extends React.Component {
     }
 
     if (!this.options.serverSide && sortIndex !== null) {
-      const sortedData = this.sortTable(tableData, sortIndex, sortDirection);
+      const sortedData = this.sortTable(tableData, sortIndex, sortDirection, columns[sortIndex].sortFn);
       tableData = sortedData.data;
     }
 
@@ -1200,7 +1201,7 @@ class MUIDataTable extends React.Component {
             sortOrder: newSortOrder,
           };
         } else {
-          const sortedData = this.sortTable(data, index, newOrder);
+          const sortedData = this.sortTable(data, index, newOrder, columns[index].sortFn);
 
           newState = {
             ...newState,
@@ -1701,7 +1702,7 @@ class MUIDataTable extends React.Component {
     }
   };
 
-  sortTable(data, col, order) {
+  sortTable(data, col, order, columnSortFn=null) {
     let dataSrc = this.options.customSort ? this.options.customSort(data, col, order || 'desc') : data;
 
     let sortedData = dataSrc.map((row, sIndex) => ({
@@ -1712,7 +1713,8 @@ class MUIDataTable extends React.Component {
     }));
 
     if (!this.options.customSort) {
-      sortedData.sort(sortCompare(order));
+      const sortFn = columnSortFn || sortCompare;
+      sortedData.sort(sortFn(order));
     }
 
     let tableData = [];

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1702,8 +1702,9 @@ class MUIDataTable extends React.Component {
     }
   };
 
-  sortTable(data, col, order, columnSortFn=null) {
-    let dataSrc = this.options.customSort ? this.options.customSort(data, col, order || 'desc') : data;
+  sortTable(data, col, order, columnSortFn = null) {
+    let hasCustomTableSort = this.options.customSort && !columnSortFn;
+    let dataSrc = hasCustomTableSort ? this.options.customSort(data, col, order || 'desc') : data;
 
     let sortedData = dataSrc.map((row, sIndex) => ({
       data: row.data[col],
@@ -1712,7 +1713,7 @@ class MUIDataTable extends React.Component {
       rowSelected: this.state.selectedRows.lookup[row.index] ? true : false,
     }));
 
-    if (!this.options.customSort) {
+    if (!hasCustomTableSort) {
       const sortFn = columnSortFn || sortCompare;
       sortedData.sort(sortFn(order));
     }

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -580,7 +580,7 @@ class MUIDataTable extends React.Component {
         searchable: true,
         download: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       };
 
       columnOrder.push(colIndex);
@@ -871,7 +871,7 @@ class MUIDataTable extends React.Component {
     }
 
     if (!this.options.serverSide && sortIndex !== null) {
-      const sortedData = this.sortTable(tableData, sortIndex, sortDirection, columns[sortIndex].sortFn);
+      const sortedData = this.sortTable(tableData, sortIndex, sortDirection, columns[sortIndex].sortCompare);
       tableData = sortedData.data;
     }
 
@@ -1201,7 +1201,7 @@ class MUIDataTable extends React.Component {
             sortOrder: newSortOrder,
           };
         } else {
-          const sortedData = this.sortTable(data, index, newOrder, columns[index].sortFn);
+          const sortedData = this.sortTable(data, index, newOrder, columns[index].sortCompare);
 
           newState = {
             ...newState,
@@ -1702,8 +1702,8 @@ class MUIDataTable extends React.Component {
     }
   };
 
-  sortTable(data, col, order, columnSortFn = null) {
-    let hasCustomTableSort = this.options.customSort && !columnSortFn;
+  sortTable(data, col, order, columnSortCompare = null) {
+    let hasCustomTableSort = this.options.customSort && !columnSortCompare;
     let dataSrc = hasCustomTableSort ? this.options.customSort(data, col, order || 'desc') : data;
 
     let sortedData = dataSrc.map((row, sIndex) => ({
@@ -1714,7 +1714,7 @@ class MUIDataTable extends React.Component {
     }));
 
     if (!hasCustomTableSort) {
-      const sortFn = columnSortFn || sortCompare;
+      const sortFn = columnSortCompare || sortCompare;
       sortedData.sort(sortFn(order));
     }
 

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -30,7 +30,7 @@ describe('<MUIDataTable />', function() {
   let defaultRenderCustomFilterList = f => f;
   let renderCustomFilterList = f => `Name: ${f}`;
 
-  before(() => {
+  beforeEach(() => {
     columns = [
       {
         name: 'Name',
@@ -112,6 +112,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customFilterListOptions: { render: renderCustomFilterList },
         customBodyRender: renderName,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -124,6 +125,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -138,6 +140,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         customBodyRender: renderCities,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -153,6 +156,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -166,6 +170,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
     ];
 
@@ -212,6 +217,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customFilterListOptions: { render: renderCustomFilterList },
         customBodyRender: renderName,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -224,6 +230,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -238,6 +245,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         customBodyRender: renderCities,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -253,6 +261,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
+        sortFn: null,
       },
       {
         display: 'true',
@@ -266,6 +275,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
     ];
 
@@ -1159,6 +1169,25 @@ describe('<MUIDataTable />', function() {
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
   });
 
+  it('should sort provided column with custom column sort function (sort by name length) in descending order', () => {
+    columns[0].options.sortFn = (order) => ({data: val1}, {data: val2}) => (val1.length - val2.length) * (order === 'asc' ? 1 : -1);
+    const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
+    const instance = shallowWrapper.instance();
+
+    instance.toggleSortColumn(0);
+    shallowWrapper.update();
+    const state = shallowWrapper.state();
+
+    const expectedResult = JSON.stringify([            
+      { data: ['Houston, James', 'Test Corp', renderCities('Dallas', { rowIndex: 0 }), 'TX', undefined], dataIndex: 3 },
+      { data: ['Walsh, John', 'Test Corp', renderCities('Hartford', { rowIndex: 1 }), null, undefined], dataIndex: 1 },      
+      { data: ['James, Joe', 'Test Corp', renderCities('Yonkers', { rowIndex: 2 }), 'NY', undefined], dataIndex: 0 },
+      { data: ['Herm, Bob', 'Test Corp', renderCities('Tampa', { rowIndex: 3 }), 'FL', undefined], dataIndex: 2 },
+    ]);
+
+    assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
+  });
+
   it('should toggle provided column when calling toggleViewCol method', () => {
     const options = {
       onViewColumnsChange: spy(),
@@ -1183,6 +1212,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         customBodyRender: renderName,
         viewColumns: true,
+        sortFn: null,
         customFilterListOptions: { render: renderCustomFilterList },
       },
       {
@@ -1196,6 +1226,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
       {
         name: 'City',
@@ -1210,6 +1241,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         customBodyRender: renderCities,
         viewColumns: true,
+        sortFn: null,
       },
       {
         name: 'State',
@@ -1225,6 +1257,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
+        sortFn: null,
       },
       {
         name: 'Empty',
@@ -1238,6 +1271,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
+        sortFn: null,
       },
     ];
 

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -30,7 +30,7 @@ describe('<MUIDataTable />', function() {
   let defaultRenderCustomFilterList = f => f;
   let renderCustomFilterList = f => `Name: ${f}`;
 
-  beforeEach(() => {
+  before(() => {
     columns = [
       {
         name: 'Name',
@@ -1170,7 +1170,8 @@ describe('<MUIDataTable />', function() {
   });
 
   it('should sort provided column with custom column sort function (sort by name length) in descending order', () => {
-    columns[0].options.sortFn = (order) => ({data: val1}, {data: val2}) => (val1.length - val2.length) * (order === 'asc' ? 1 : -1);
+    columns[0].options.sortFn = order => ({ data: val1 }, { data: val2 }) =>
+      (val1.length - val2.length) * (order === 'asc' ? -1 : 1);
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
     const instance = shallowWrapper.instance();
 
@@ -1178,14 +1179,16 @@ describe('<MUIDataTable />', function() {
     shallowWrapper.update();
     const state = shallowWrapper.state();
 
-    const expectedResult = JSON.stringify([            
+    const expectedResult = JSON.stringify([
       { data: ['Houston, James', 'Test Corp', renderCities('Dallas', { rowIndex: 0 }), 'TX', undefined], dataIndex: 3 },
-      { data: ['Walsh, John', 'Test Corp', renderCities('Hartford', { rowIndex: 1 }), null, undefined], dataIndex: 1 },      
+      { data: ['Walsh, John', 'Test Corp', renderCities('Hartford', { rowIndex: 1 }), null, undefined], dataIndex: 1 },
       { data: ['James, Joe', 'Test Corp', renderCities('Yonkers', { rowIndex: 2 }), 'NY', undefined], dataIndex: 0 },
       { data: ['Herm, Bob', 'Test Corp', renderCities('Tampa', { rowIndex: 3 }), 'FL', undefined], dataIndex: 2 },
     ]);
 
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
+
+    columns[0].options.sortFn = null;
   });
 
   it('should toggle provided column when calling toggleViewCol method', () => {

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -112,7 +112,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customFilterListOptions: { render: renderCustomFilterList },
         customBodyRender: renderName,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -125,7 +125,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -140,7 +140,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         customBodyRender: renderCities,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -156,7 +156,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -170,7 +170,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
     ];
 
@@ -217,7 +217,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customFilterListOptions: { render: renderCustomFilterList },
         customBodyRender: renderName,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -230,7 +230,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -245,7 +245,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         viewColumns: true,
         customBodyRender: renderCities,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -261,7 +261,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         display: 'true',
@@ -275,7 +275,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
     ];
 
@@ -1170,7 +1170,7 @@ describe('<MUIDataTable />', function() {
   });
 
   it('should sort provided column with custom column sort function (sort by name length) in descending order', () => {
-    columns[0].options.sortFn = order => ({ data: val1 }, { data: val2 }) =>
+    columns[0].options.sortCompare = order => ({ data: val1 }, { data: val2 }) =>
       (val1.length - val2.length) * (order === 'asc' ? -1 : 1);
     const shallowWrapper = shallow(<MUIDataTable columns={columns} data={data} />).dive();
     const instance = shallowWrapper.instance();
@@ -1188,7 +1188,7 @@ describe('<MUIDataTable />', function() {
 
     assert.deepEqual(JSON.stringify(state.displayData), expectedResult);
 
-    columns[0].options.sortFn = null;
+    columns[0].options.sortCompare = null;
   });
 
   it('should toggle provided column when calling toggleViewCol method', () => {
@@ -1215,7 +1215,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         customBodyRender: renderName,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
         customFilterListOptions: { render: renderCustomFilterList },
       },
       {
@@ -1229,7 +1229,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         name: 'City',
@@ -1244,7 +1244,7 @@ describe('<MUIDataTable />', function() {
         searchable: true,
         customBodyRender: renderCities,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         name: 'State',
@@ -1260,7 +1260,7 @@ describe('<MUIDataTable />', function() {
         viewColumns: true,
         customBodyRender: renderState,
         customHeadRender: renderHead,
-        sortFn: null,
+        sortCompare: null,
       },
       {
         name: 'Empty',
@@ -1274,7 +1274,7 @@ describe('<MUIDataTable />', function() {
         download: true,
         searchable: true,
         viewColumns: true,
-        sortFn: null,
+        sortCompare: null,
       },
     ];
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/gregnb/mui-datatables/pull/951. I've simply updated the code for the latest branch, expanded upon the example, and made it so sortCompare takes precedence over customSort.

This feature has been requested/come up several times recently (https://github.com/gregnb/mui-datatables/issues/1011#issuecomment-645651798, https://github.com/gregnb/mui-datatables/issues/1336#issuecomment-648682275, https://github.com/gregnb/mui-datatables/issues/1394). 

sortCompare Interface
---------
```typescript
(order: 'asc'|'desc') => ({data: val1}, {data: val2}) => number
```

example:
```javascript
columns = [
  {
    name: "Name",
    options: {
      sort: true,
      sortCompare: order => ({data: val1}, {data: val2}) => (val1.length - val2.length) * (order === 'asc' ? 1 : -1)
    }
  }
]
```

If both customSort and sortCompare are defined, sortCompare will take precedence.