### PR TITLE
Grouping Feature

### DIFF
--- a/examples/Router/ExamplesGrid.js
+++ b/examples/Router/ExamplesGrid.js
@@ -54,7 +54,6 @@ class ExamplesGrid extends React.Component {
 
     const examplesSortedKeys = Object.keys(examplesSorted).filter((item) => {
       if (this.state.searchVal === '') return true;
-      console.dir(item);
       return item.toLowerCase().indexOf( this.state.searchVal.toLowerCase() ) !== -1 ? true : false;
     });
 

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -34,6 +34,7 @@ import CustomComponents from './custom-components';
 import InfiniteScrolling from './infinite-scrolling';
 import Themes from './themes';
 import LargeDataSet from './large-data-set';
+import Grouping from './grouping';
 
 /**
  * Here you can add any extra examples with the Card label as the key, and the component to render as the value
@@ -60,6 +61,7 @@ export default {
   'Draggable Columns': DraggableColumns,
   'Expandable Rows': ExpandableRows,
   'Fixed Header': FixedHeader,
+  'Grouping': Grouping,
   'Hide Columns Print': HideColumnsPrint,
   'Infinite Scrolling': InfiniteScrolling,
   'Large Data Set': LargeDataSet,

--- a/examples/grouping/index.js
+++ b/examples/grouping/index.js
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import MUIDataTable from '../../src/';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+
+function Example() {
+  const [responsive, setResponsive] = useState('vertical');
+  const [tableBodyHeight, setTableBodyHeight] = useState('400px');
+  const [tableBodyMaxHeight, setTableBodyMaxHeight] = useState('');
+
+  const columns = [
+    {
+      name: 'name',
+      label: 'Name',
+      options: {
+        setCellHeaderProps: () => ({
+          style: {
+            width: '25%'
+          }
+        }),
+      }
+    }, 
+    {
+      name: 'title',
+      label: 'Title',
+      options: {
+        setCellHeaderProps: () => ({
+          style: {
+            width: '25%'
+          }
+        }),
+      }
+    }, 
+    {
+      name: 'location',
+      label: 'Location',
+      options: {
+        setCellHeaderProps: () => ({
+          style: {
+            width: '25%'
+          }
+        }),
+      }
+    }, 
+    {
+      name: 'gender',
+      label: 'Gender'
+    }
+  ];
+
+  const options = {
+    filter: true,
+    filterType: 'dropdown',
+    responsive,
+    pagination: false,
+    draggableColumns: {
+      enabled: true,
+    },
+    onTableChange: (action, state) => {
+      console.log(action);
+      console.dir(state);
+    },
+    grouping: {
+      columnIndexes: [1, 3]
+    }
+  };
+
+  const data = [
+    ['Gabby George', 'Business Analyst', 'Minneapolis', 'female'],
+    ['Aiden Lloyd', "Business Consultant", 'Dallas', 'male'],
+    ['Jaden Collins', 'Attorney', 'Santa Ana', 'male'],
+    ['Franky Rees', 'Business Analyst', 'St. Petersburg', 'male'],
+    ['Aaren Rose', null, 'Toledo', 'male'],
+    ['Johnny Jones', 'Business Analyst', 'St. Petersburg', 'male'],
+    ['Jimmy Johns', 'Business Analyst', 'Baltimore', 'male'],
+    ['Jack Jackson', 'Business Analyst', 'El Paso', 'male'],
+    ['Joe Jones', 'Computer Programmer', 'El Paso', 'male'],
+    ['Jacky Jackson', 'Business Consultant', 'Baltimore', 'female'],
+    ['Jo Jo', 'Software Developer', 'Washington DC', 'male'],
+    ['Donna Marie', 'Business Manager', 'Annapolis', 'female'],
+    ['Armin Tamzarian', 'Principal', 'Springfield', 'male'],
+    ['Gerald Strickland', 'Principal', 'Hill Valley', 'male'],
+    ['Doc Brown', 'Computer Programmer', 'Hill Valley', 'male'],
+    ['Angela Li', 'Principal', 'Lawndale', 'female'],
+    ['Jake Morgendorffer', 'Business Analyst', 'Lawndale', 'male'],
+  ];
+
+  return (
+    <React.Fragment>
+      <FormControl>
+        <InputLabel id="demo-simple-select-label">Responsive Option</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={responsive}
+          style={{ width: '200px', marginBottom: '10px', marginRight: 10 }}
+          onChange={e => setResponsive(e.target.value)}>
+          <MenuItem value={'vertical'}>vertical</MenuItem>
+          <MenuItem value={'standard'}>standard</MenuItem>
+          <MenuItem value={'simple'}>simple</MenuItem>
+
+          <MenuItem value={'scroll'}>scroll (deprecated)</MenuItem>
+          <MenuItem value={'scrollMaxHeight'}>scrollMaxHeight (deprecated)</MenuItem>
+          <MenuItem value={'stacked'}>stacked (deprecated)</MenuItem>
+        </Select>
+      </FormControl>
+      <MUIDataTable title={'ACME Employee list'} data={data} columns={columns} options={options} />
+    </React.Fragment>
+  );
+}
+
+export default Example;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -5,6 +5,7 @@ import MuiTableBody from '@material-ui/core/TableBody';
 import TableBodyCell from './TableBodyCell';
 import TableBodyRow from './TableBodyRow';
 import TableSelectCell from './TableSelectCell';
+import TableBodyRows from './TableBodyRows';
 import { withStyles } from '@material-ui/core/styles';
 import cloneDeep from 'lodash.clonedeep';
 import { getPageValue } from '../utils';
@@ -86,141 +87,6 @@ class TableBody extends React.Component {
     return rows.length ? rows : null;
   }
 
-  getRowIndex(index) {
-    const { page, rowsPerPage, options } = this.props;
-
-    if (options.serverSide) {
-      return index;
-    }
-
-    const startIndex = page === 0 ? 0 : page * rowsPerPage;
-    return startIndex + index;
-  }
-
-  isRowSelected(dataIndex) {
-    const { selectedRows } = this.props;
-    return selectedRows.lookup && selectedRows.lookup[dataIndex] ? true : false;
-  }
-
-  isRowExpanded(dataIndex) {
-    const { expandedRows } = this.props;
-    return expandedRows.lookup && expandedRows.lookup[dataIndex] ? true : false;
-  }
-
-  isRowSelectable(dataIndex, selectedRows) {
-    const { options } = this.props;
-    selectedRows = selectedRows || this.props.selectedRows;
-
-    if (options.isRowSelectable) {
-      return options.isRowSelectable(dataIndex, selectedRows);
-    } else {
-      return true;
-    }
-  }
-
-  isRowExpandable(dataIndex) {
-    const { options, expandedRows } = this.props;
-    if (options.isRowExpandable) {
-      return options.isRowExpandable(dataIndex, expandedRows);
-    } else {
-      return true;
-    }
-  }
-
-  handleRowSelect = (data, event) => {
-    let shiftKey = event && event.nativeEvent ? event.nativeEvent.shiftKey : false;
-    let shiftAdjacentRows = [];
-    let previousSelectedRow = this.props.previousSelectedRow;
-
-    // If the user is pressing shift and has previously clicked another row.
-    if (shiftKey && previousSelectedRow && previousSelectedRow.index < this.props.data.length) {
-      let curIndex = previousSelectedRow.index;
-
-      // Create a copy of the selectedRows object. This will be used and modified
-      // below when we see if we can add adjacent rows.
-      let selectedRows = cloneDeep(this.props.selectedRows);
-
-      // Add the clicked on row to our copy of selectedRows (if it isn't already present).
-      let clickedDataIndex = this.props.data[data.index].dataIndex;
-      if (selectedRows.data.filter(d => d.dataIndex === clickedDataIndex).length === 0) {
-        selectedRows.data.push({
-          index: data.index,
-          dataIndex: clickedDataIndex,
-        });
-        selectedRows.lookup[clickedDataIndex] = true;
-      }
-
-      while (curIndex !== data.index) {
-        let dataIndex = this.props.data[curIndex].dataIndex;
-
-        if (this.isRowSelectable(dataIndex, selectedRows)) {
-          let lookup = {
-            index: curIndex,
-            dataIndex: dataIndex,
-          };
-
-          // Add adjacent row to temp selectedRow object if it isn't present.
-          if (selectedRows.data.filter(d => d.dataIndex === dataIndex).length === 0) {
-            selectedRows.data.push(lookup);
-            selectedRows.lookup[dataIndex] = true;
-          }
-
-          shiftAdjacentRows.push(lookup);
-        }
-        curIndex = data.index > curIndex ? curIndex + 1 : curIndex - 1;
-      }
-    }
-    this.props.selectRowUpdate('cell', data, shiftAdjacentRows);
-  };
-
-  handleRowClick = (row, data, event) => {
-    // Don't trigger onRowClick if the event was actually the expandable icon.
-    if (
-      event.target.id === 'expandable-button' ||
-      (event.target.nodeName === 'path' && event.target.parentNode.id === 'expandable-button')
-    ) {
-      return;
-    }
-
-    // Don't trigger onRowClick if the event was actually a row selection via checkbox
-    if (event.target.id && event.target.id.startsWith('MUIDataTableSelectCell')) return;
-
-    // Check if we should toggle row select when row is clicked anywhere
-    if (
-      this.props.options.selectableRowsOnClick &&
-      this.props.options.selectableRows !== 'none' &&
-      this.isRowSelectable(data.dataIndex, this.props.selectedRows)
-    ) {
-      const selectRow = { index: data.rowIndex, dataIndex: data.dataIndex };
-      this.handleRowSelect(selectRow, event);
-    }
-    // Check if we should trigger row expand when row is clicked anywhere
-    if (
-      this.props.options.expandableRowsOnClick &&
-      this.props.options.expandableRows &&
-      this.isRowExpandable(data.dataIndex, this.props.expandedRows)
-    ) {
-      const expandRow = { index: data.rowIndex, dataIndex: data.dataIndex };
-      this.props.toggleExpandRow(expandRow);
-    }
-
-    // Don't trigger onRowClick if the event was actually a row selection via click
-    if (this.props.options.selectableRowsOnClick) return;
-
-    this.props.options.onRowClick && this.props.options.onRowClick(row, data, event);
-  };
-
-  processRow = (row, columnOrder) => {
-    let ret = [];
-    for (let ii = 0; ii < row.length; ii++) {
-      ret.push({
-        value: row[columnOrder[ii]],
-        index: columnOrder[ii],
-      });
-    }
-    return ret;
-  };
-
   render() {
     const {
       classes,
@@ -232,103 +98,27 @@ class TableBody extends React.Component {
       tableId,
     } = this.props;
     const tableRows = this.buildRows();
-    const visibleColCnt = columns.filter(c => c.display === 'true').length;
 
     return (
       <MuiTableBody>
-        {tableRows && tableRows.length > 0 ? (
-          tableRows.map((data, rowIndex) => {
-            const { data: row, dataIndex } = data;
-
-            if (options.customRowRender) {
-              return options.customRowRender(row, dataIndex, rowIndex);
-            }
-
-            let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;
-            let isRowSelectable = this.isRowSelectable(dataIndex);
-            let bodyClasses = options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) || {} : {};
-
-            const processedRow = this.processRow(row, columnOrder);
-
-            return (
-              <React.Fragment key={rowIndex}>
-                <TableBodyRow
-                  {...bodyClasses}
-                  options={options}
-                  rowSelected={isRowSelected}
-                  isRowSelectable={isRowSelectable}
-                  onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
-                  className={clsx({
-                    [classes.lastStackedCell]:
-                      options.responsive === 'vertical' ||
-                      options.responsive === 'stacked' ||
-                      options.responsive === 'stackedFullWidth',
-                    [classes.lastSimpleCell]: options.responsive === 'simple',
-                    [bodyClasses.className]: bodyClasses.className,
-                  })}
-                  data-testid={'MUIDataTableBodyRow-' + dataIndex}
-                  id={'MUIDataTableBodyRow-' + dataIndex}>
-                  <TableSelectCell
-                    onChange={this.handleRowSelect.bind(null, {
-                      index: this.getRowIndex(rowIndex),
-                      dataIndex: dataIndex,
-                    })}
-                    onExpand={toggleExpandRow.bind(null, {
-                      index: this.getRowIndex(rowIndex),
-                      dataIndex: dataIndex,
-                    })}
-                    fixedHeader={options.fixedHeader}
-                    fixedSelectColumn={options.fixedSelectColumn}
-                    checked={isRowSelected}
-                    expandableOn={options.expandableRows}
-                    // When rows are expandable, but this particular row isn't expandable, set this to true.
-                    // This will add a new class to the toggle button, MUIDataTableSelectCell-expandDisabled.
-                    hideExpandButton={!this.isRowExpandable(dataIndex) && options.expandableRows}
-                    selectableOn={options.selectableRows}
-                    selectableRowsHideCheckboxes={options.selectableRowsHideCheckboxes}
-                    isRowExpanded={this.isRowExpanded(dataIndex)}
-                    isRowSelectable={isRowSelectable}
-                    id={'MUIDataTableSelectCell-' + dataIndex}
-                    components={components}
-                  />
-                  {processedRow.map(
-                    column =>
-                      columns[column.index].display === 'true' && (
-                        <TableBodyCell
-                          {...(columns[column.index].setCellProps
-                            ? columns[column.index].setCellProps(column.value, dataIndex, column.index) || {}
-                            : {})}
-                          data-testid={`MuiDataTableBodyCell-${column.index}-${rowIndex}`}
-                          dataIndex={dataIndex}
-                          rowIndex={rowIndex}
-                          colIndex={column.index}
-                          columnHeader={columns[column.index].label}
-                          print={columns[column.index].print}
-                          options={options}
-                          tableId={tableId}
-                          key={column.index}>
-                          {column.value}
-                        </TableBodyCell>
-                      ),
-                  )}
-                </TableBodyRow>
-                {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex })}
-              </React.Fragment>
-            );
-          })
-        ) : (
-          <TableBodyRow options={options}>
-            <TableBodyCell
-              colSpan={options.selectableRows !== 'none' || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
-              options={options}
-              colIndex={0}
-              rowIndex={0}>
-              <Typography variant="body1" className={classes.emptyTitle} component={'div'}>
-                {options.textLabels.body.noMatch}
-              </Typography>
-            </TableBodyCell>
-          </TableBodyRow>
-        )}
+        <TableBodyRows
+          tableRows={tableRows} 
+          data={this.props.data}
+          count={this.props.count}
+          columns={this.props.columns}
+          page={this.props.page}
+          rowsPerPage={this.props.rowsPerPage}
+          selectedRows={this.props.selectedRows}
+          selectRowUpdate={this.props.selectRowUpdate}
+          previousSelectedRow={this.props.previousSelectedRow}
+          expandedRows={this.props.expandedRows}
+          toggleExpandRow={this.props.toggleExpandRow}
+          options={this.props.options}
+          columnOrder={this.props.columnOrder}
+          filterList={this.props.filterList}
+          components={this.props.components}
+          tableId={this.props.tableId}
+        />
       </MuiTableBody>
     );
   }

--- a/src/components/TableBodyGroupDataRow.js
+++ b/src/components/TableBodyGroupDataRow.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TableBodyRows from './TableBodyRows';
+import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
+import { getPageValue } from '../utils';
+import clsx from 'clsx';
+
+const defaultBodyStyles = theme => ({
+  root: {},
+});
+
+function TableBodyGroupDataRow(props) {
+  const {
+    row,
+  } = props;
+console.dir(props);
+  return (
+    <TableBodyRows
+      tableRows={row.data.data} 
+      data={props.data}
+      count={props.count}
+      columns={props.columns}
+      page={props.page}
+      rowsPerPage={props.rowsPerPage}
+      selectedRows={props.selectedRows}
+      selectRowUpdate={props.selectRowUpdate}
+      previousSelectedRow={props.previousSelectedRow}
+      expandedRows={props.expandedRows}
+      toggleExpandRow={props.toggleExpandRow}
+      options={props.options}
+      columnOrder={props.columnOrder}
+      filterList={props.filterList}
+      components={props.components}
+      tableId={props.tableId}
+    />
+  );
+}
+
+export default TableBodyGroupDataRow;

--- a/src/components/TableBodyGroupHeaderRow.js
+++ b/src/components/TableBodyGroupHeaderRow.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import TableBodyCell from './TableBodyCell';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import TableSelectCell from './TableSelectCell';
+import { makeStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
+import IconButton from '@material-ui/core/IconButton';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
+const useStyles = makeStyles(
+  theme => ({
+    root: {},
+    columnName: {
+      fontWeight: 'bold',
+      display: 'inline-block',
+    },
+    columnValue: {
+      marginLeft: '6px',
+      display: 'inline-block',
+    },
+    icon: {
+      cursor: 'pointer',
+      transition: 'transform 0.25s',
+    },
+    expanded: {
+      transform: 'rotate(90deg)',
+    },
+    tableRow: {
+      padding: "4px 8px 8px 4px"
+    },
+    expandButton: {
+      marginRight: "10px"
+    }
+  }),
+  {name: 'MUIDataTableBodyGroupHeaderRow'}
+);
+
+function TableBodyGroupHeaderRow(props) {
+  const {
+    columns,
+    options,
+    components = {},
+    tableId,
+    row,
+  } = props;
+  const classes = useStyles();
+
+  const onExpand = () => {};
+
+  const iconClass = clsx({
+    [classes.icon]: true,
+    [classes.expanded]: row.expanded,
+  });
+
+  const getLevelOffset = (level) => {
+    return ((level-1) * 32) + 'px';
+  };
+
+  let bodyClasses = options.setRowProps ? options.setRowProps(row, null, null) || {} : {};
+  //console.dir(row);
+  return (
+    <TableRow
+      {...bodyClasses}
+      className={clsx({
+        [bodyClasses.className]: bodyClasses.className,
+        [classes.tableRow]: true,
+      })}>
+      <TableCell
+        className={classes.tableRow}
+        colSpan={1000}>
+        <IconButton
+          className={classes.expandButton}
+          style={{
+            marginLeft: getLevelOffset(row.level)
+          }}
+          onClick={row.onExpansionChange}>
+          <KeyboardArrowRight id="expandable-button" className={iconClass} />
+        </IconButton>
+        <div className={classes.columnName}>{row.columnLabel}:</div><div className={classes.columnValue}>{row.columnValue}</div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default TableBodyGroupHeaderRow;

--- a/src/components/TableBodyGroups.js
+++ b/src/components/TableBodyGroups.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import MuiTableBody from '@material-ui/core/TableBody';
+import TableBodyCell from './TableBodyCell';
+import TableBodyRow from './TableBodyRow';
+import TableSelectCell from './TableSelectCell';
+import TableBodyGroupHeaderRow from './TableBodyGroupHeaderRow';
+import TableBodyGroupDataRow from './TableBodyGroupDataRow';
+import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
+import { getPageValue } from '../utils';
+import clsx from 'clsx';
+
+const defaultBodyStyles = theme => ({
+  root: {},
+});
+
+class TableBody extends React.Component {
+  static propTypes = {
+    /** Data used to describe table */
+    data: PropTypes.array.isRequired,
+    /** Total number of data rows */
+    count: PropTypes.number.isRequired,
+    /** Columns used to describe table */
+    columns: PropTypes.array.isRequired,
+    /** Options used to describe table */
+    options: PropTypes.object.isRequired,
+    /** Data used to filter table against */
+    filterList: PropTypes.array,
+    /** Callback to execute when row is clicked */
+    onRowClick: PropTypes.func,
+    /** Table rows expanded */
+    expandedRows: PropTypes.object,
+    /** Table rows selected */
+    selectedRows: PropTypes.object,
+    /** Callback to trigger table row select */
+    selectRowUpdate: PropTypes.func,
+    /** The most recent row to have been selected/unselected */
+    previousSelectedRow: PropTypes.object,
+    /** Data used to search table against */
+    searchText: PropTypes.string,
+    /** Toggle row expandable */
+    toggleExpandRow: PropTypes.func,
+    /** Extend the style applied to components */
+    classes: PropTypes.object,
+  };
+
+  static defaultProps = {
+    toggleExpandRow: () => {},
+  };
+
+  flattenGroups(rows, rootGroup, columns, grouping, isGroupExpanded) {
+
+    for (let prop in rootGroup.groups) {
+      let group = rootGroup.groups[prop];
+      if (group.data) {
+        let isExpanded = isGroupExpanded(grouping, group.group);
+        rows.push({
+          rowType: 'group',
+          level: rootGroup.level,
+          id: group.group.join('___GROUPJOIN___'),
+          columnIndex: rootGroup.groupColumnIndex,
+          columnName: columns[rootGroup.groupColumnIndex].name,
+          columnLabel: columns[rootGroup.groupColumnIndex].label || columns[rootGroup.groupColumnIndex].name,
+          columnValue: prop,
+          expanded: isExpanded,
+          onExpansionChange: group.onExpansionChange,
+        });
+
+        if (isExpanded) {
+          rows.push({
+            rowType: 'data',
+            id: group.group.join('___GROUPJOIN___') + '_data',
+            data: group
+          });
+        }
+
+      } else {
+        let isExpanded = isGroupExpanded(grouping, group.group);
+        rows.push({
+          rowType: 'group',
+          level: rootGroup.level,
+          id: group.group.join('___GROUPJOIN___'),
+          columnIndex: rootGroup.groupColumnIndex,
+          columnName: columns[rootGroup.groupColumnIndex].name,
+          columnLabel: columns[rootGroup.groupColumnIndex].label || columns[rootGroup.groupColumnIndex].name,
+          columnValue: prop,
+          expanded: isExpanded,
+          onExpansionChange: group.onExpansionChange,
+        });
+
+        if (isExpanded) {
+          this.flattenGroups(rows, rootGroup.groups[prop], columns, grouping, isGroupExpanded);
+        }
+
+      }
+    }
+
+    return rows;
+  }
+
+  buildRows(groupingData, columns, grouping, isGroupExpanded) {
+    let rows = this.flattenGroups([], groupingData, columns, grouping, isGroupExpanded);
+    return rows;
+  }
+
+  render() {
+    const {
+      grouping,
+      isGroupExpanded,
+      classes,
+      columns,
+      groupingData,
+    } = this.props;
+    let tableData = this.props.data;
+
+    let rows = this.buildRows(groupingData, columns, grouping, isGroupExpanded);
+
+    console.log('rows');
+    console.dir(rows);
+
+    return (
+      <MuiTableBody>
+        {rows.map((data, rowIndex) => {
+          let RowComponent = (data.rowType === 'group') ? TableBodyGroupHeaderRow : TableBodyGroupDataRow;
+          return (
+            <RowComponent
+              row={data}
+              data={tableData}
+              columns={columns}
+              count={this.props.count}
+              page={this.props.page}
+              rowsPerPage={this.props.rowsPerPage}
+              selectedRows={this.props.selectedRows}
+              selectRowUpdate={this.props.selectRowUpdate}
+              previousSelectedRow={this.props.previousSelectedRow}
+              expandedRows={this.props.expandedRows}
+              toggleExpandRow={this.props.toggleExpandRow}
+              options={this.props.options}
+              columnOrder={this.props.columnOrder}
+              filterList={this.props.filterList}
+              components={this.props.components}
+              tableId={this.props.tableId}
+              key={data.id}
+            />
+          );
+        })}
+      </MuiTableBody>
+    );
+  }
+}
+
+export default withStyles(defaultBodyStyles, { name: 'MUIDataTableBody' })(TableBody);

--- a/src/components/TableBodyRows.js
+++ b/src/components/TableBodyRows.js
@@ -1,0 +1,316 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import MuiTableBody from '@material-ui/core/TableBody';
+import TableBodyCell from './TableBodyCell';
+import TableBodyRow from './TableBodyRow';
+import TableSelectCell from './TableSelectCell';
+import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
+import { getPageValue } from '../utils';
+import clsx from 'clsx';
+
+const defaultBodyStyles = theme => ({
+  root: {},
+  emptyTitle: {
+    textAlign: 'center',
+  },
+  lastStackedCell: {
+    [theme.breakpoints.down('sm')]: {
+      '& td:last-child': {
+        borderBottom: 'none',
+      },
+    },
+  },
+  lastSimpleCell: {
+    [theme.breakpoints.down('xs')]: {
+      '& td:last-child': {
+        borderBottom: 'none',
+      },
+    },
+  },
+});
+
+class TableBodyRows extends React.Component {
+  static propTypes = {
+    /** Data used to describe table */
+    data: PropTypes.array.isRequired,
+    /** Total number of data rows */
+    count: PropTypes.number.isRequired,
+    /** Columns used to describe table */
+    columns: PropTypes.array.isRequired,
+    /** Options used to describe table */
+    options: PropTypes.object.isRequired,
+    /** Data used to filter table against */
+    filterList: PropTypes.array,
+    /** Callback to execute when row is clicked */
+    onRowClick: PropTypes.func,
+    /** Table rows expanded */
+    expandedRows: PropTypes.object,
+    /** Table rows selected */
+    selectedRows: PropTypes.object,
+    /** Callback to trigger table row select */
+    selectRowUpdate: PropTypes.func,
+    /** The most recent row to have been selected/unselected */
+    previousSelectedRow: PropTypes.object,
+    /** Data used to search table against */
+    searchText: PropTypes.string,
+    /** Toggle row expandable */
+    toggleExpandRow: PropTypes.func,
+    /** Extend the style applied to components */
+    classes: PropTypes.object,
+  };
+
+  static defaultProps = {
+    toggleExpandRow: () => {},
+  };
+
+  getRowIndex(index) {
+    const { page, rowsPerPage, options } = this.props;
+
+    if (options.serverSide) {
+      return index;
+    }
+
+    const startIndex = page === 0 ? 0 : page * rowsPerPage;
+    return startIndex + index;
+  }
+
+  isRowSelected(dataIndex) {
+    const { selectedRows } = this.props;
+    return selectedRows.lookup && selectedRows.lookup[dataIndex] ? true : false;
+  }
+
+  isRowExpanded(dataIndex) {
+    const { expandedRows } = this.props;
+    return expandedRows.lookup && expandedRows.lookup[dataIndex] ? true : false;
+  }
+
+  isRowSelectable(dataIndex, selectedRows) {
+    const { options } = this.props;
+    selectedRows = selectedRows || this.props.selectedRows;
+
+    if (options.isRowSelectable) {
+      return options.isRowSelectable(dataIndex, selectedRows);
+    } else {
+      return true;
+    }
+  }
+
+  isRowExpandable(dataIndex) {
+    const { options, expandedRows } = this.props;
+    if (options.isRowExpandable) {
+      return options.isRowExpandable(dataIndex, expandedRows);
+    } else {
+      return true;
+    }
+  }
+
+  handleRowSelect = (data, event) => {
+    let shiftKey = event && event.nativeEvent ? event.nativeEvent.shiftKey : false;
+    let shiftAdjacentRows = [];
+    let previousSelectedRow = this.props.previousSelectedRow;
+
+    // If the user is pressing shift and has previously clicked another row.
+    if (shiftKey && previousSelectedRow && previousSelectedRow.index < this.props.data.length) {
+      let curIndex = previousSelectedRow.index;
+
+      // Create a copy of the selectedRows object. This will be used and modified
+      // below when we see if we can add adjacent rows.
+      let selectedRows = cloneDeep(this.props.selectedRows);
+
+      // Add the clicked on row to our copy of selectedRows (if it isn't already present).
+      let clickedDataIndex = this.props.data[data.index].dataIndex;
+      if (selectedRows.data.filter(d => d.dataIndex === clickedDataIndex).length === 0) {
+        selectedRows.data.push({
+          index: data.index,
+          dataIndex: clickedDataIndex,
+        });
+        selectedRows.lookup[clickedDataIndex] = true;
+      }
+
+      while (curIndex !== data.index) {
+        let dataIndex = this.props.data[curIndex].dataIndex;
+
+        if (this.isRowSelectable(dataIndex, selectedRows)) {
+          let lookup = {
+            index: curIndex,
+            dataIndex: dataIndex,
+          };
+
+          // Add adjacent row to temp selectedRow object if it isn't present.
+          if (selectedRows.data.filter(d => d.dataIndex === dataIndex).length === 0) {
+            selectedRows.data.push(lookup);
+            selectedRows.lookup[dataIndex] = true;
+          }
+
+          shiftAdjacentRows.push(lookup);
+        }
+        curIndex = data.index > curIndex ? curIndex + 1 : curIndex - 1;
+      }
+    }
+    this.props.selectRowUpdate('cell', data, shiftAdjacentRows);
+  };
+
+  handleRowClick = (row, data, event) => {
+    // Don't trigger onRowClick if the event was actually the expandable icon.
+    if (
+      event.target.id === 'expandable-button' ||
+      (event.target.nodeName === 'path' && event.target.parentNode.id === 'expandable-button')
+    ) {
+      return;
+    }
+
+    // Don't trigger onRowClick if the event was actually a row selection via checkbox
+    if (event.target.id && event.target.id.startsWith('MUIDataTableSelectCell')) return;
+
+    // Check if we should toggle row select when row is clicked anywhere
+    if (
+      this.props.options.selectableRowsOnClick &&
+      this.props.options.selectableRows !== 'none' &&
+      this.isRowSelectable(data.dataIndex, this.props.selectedRows)
+    ) {
+      const selectRow = { index: data.rowIndex, dataIndex: data.dataIndex };
+      this.handleRowSelect(selectRow, event);
+    }
+    // Check if we should trigger row expand when row is clicked anywhere
+    if (
+      this.props.options.expandableRowsOnClick &&
+      this.props.options.expandableRows &&
+      this.isRowExpandable(data.dataIndex, this.props.expandedRows)
+    ) {
+      const expandRow = { index: data.rowIndex, dataIndex: data.dataIndex };
+      this.props.toggleExpandRow(expandRow);
+    }
+
+    // Don't trigger onRowClick if the event was actually a row selection via click
+    if (this.props.options.selectableRowsOnClick) return;
+
+    this.props.options.onRowClick && this.props.options.onRowClick(row, data, event);
+  };
+
+  processRow = (row, columnOrder) => {
+    let ret = [];
+    for (let ii = 0; ii < row.length; ii++) {
+      ret.push({
+        value: row[columnOrder[ii]],
+        index: columnOrder[ii],
+      });
+    }
+    return ret;
+  };
+
+  render() {
+    const {
+      classes,
+      columns,
+      toggleExpandRow,
+      options,
+      columnOrder = this.props.columns.map((item, idx) => idx),
+      components = {},
+      tableId,
+      tableRows,
+    } = this.props;
+    const visibleColCnt = columns.filter(c => c.display === 'true').length;
+
+    return (
+      <React.Fragment>
+        {tableRows && tableRows.length > 0 ? (
+          tableRows.map((data, rowIndex) => {
+            const { data: row, dataIndex } = data;
+
+            if (options.customRowRender) {
+              return options.customRowRender(row, dataIndex, rowIndex);
+            }
+
+            let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;
+            let isRowSelectable = this.isRowSelectable(dataIndex);
+            let bodyClasses = options.setRowProps ? options.setRowProps(row, dataIndex, rowIndex) || {} : {};
+
+            const processedRow = this.processRow(row, columnOrder);
+
+            return (
+              <React.Fragment key={rowIndex}>
+                <TableBodyRow
+                  {...bodyClasses}
+                  options={options}
+                  rowSelected={isRowSelected}
+                  isRowSelectable={isRowSelectable}
+                  onClick={this.handleRowClick.bind(null, row, { rowIndex, dataIndex })}
+                  className={clsx({
+                    [classes.lastStackedCell]:
+                      options.responsive === 'vertical' ||
+                      options.responsive === 'stacked' ||
+                      options.responsive === 'stackedFullWidth',
+                    [classes.lastSimpleCell]: options.responsive === 'simple',
+                    [bodyClasses.className]: bodyClasses.className,
+                  })}
+                  data-testid={'MUIDataTableBodyRow-' + dataIndex}
+                  id={'MUIDataTableBodyRow-' + dataIndex}>
+                  <TableSelectCell
+                    onChange={this.handleRowSelect.bind(null, {
+                      index: this.getRowIndex(rowIndex),
+                      dataIndex: dataIndex,
+                    })}
+                    onExpand={toggleExpandRow.bind(null, {
+                      index: this.getRowIndex(rowIndex),
+                      dataIndex: dataIndex,
+                    })}
+                    fixedHeader={options.fixedHeader}
+                    fixedSelectColumn={options.fixedSelectColumn}
+                    checked={isRowSelected}
+                    expandableOn={options.expandableRows}
+                    // When rows are expandable, but this particular row isn't expandable, set this to true.
+                    // This will add a new class to the toggle button, MUIDataTableSelectCell-expandDisabled.
+                    hideExpandButton={!this.isRowExpandable(dataIndex) && options.expandableRows}
+                    selectableOn={options.selectableRows}
+                    selectableRowsHideCheckboxes={options.selectableRowsHideCheckboxes}
+                    isRowExpanded={this.isRowExpanded(dataIndex)}
+                    isRowSelectable={isRowSelectable}
+                    id={'MUIDataTableSelectCell-' + dataIndex}
+                    components={components}
+                  />
+                  {processedRow.map(
+                    column =>
+                      columns[column.index].display === 'true' && (
+                        <TableBodyCell
+                          {...(columns[column.index].setCellProps
+                            ? columns[column.index].setCellProps(column.value, dataIndex, column.index) || {}
+                            : {})}
+                          data-testid={`MuiDataTableBodyCell-${column.index}-${rowIndex}`}
+                          dataIndex={dataIndex}
+                          rowIndex={rowIndex}
+                          colIndex={column.index}
+                          columnHeader={columns[column.index].label}
+                          print={columns[column.index].print}
+                          options={options}
+                          tableId={tableId}
+                          key={column.index}>
+                          {column.value}
+                        </TableBodyCell>
+                      ),
+                  )}
+                </TableBodyRow>
+                {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex })}
+              </React.Fragment>
+            );
+          })
+        ) : (
+          <TableBodyRow options={options}>
+            <TableBodyCell
+              colSpan={options.selectableRows !== 'none' || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
+              options={options}
+              colIndex={0}
+              rowIndex={0}>
+              <Typography variant="body1" className={classes.emptyTitle} component={'div'}>
+                {options.textLabels.body.noMatch}
+              </Typography>
+            </TableBodyCell>
+          </TableBodyRow>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+export default withStyles(defaultBodyStyles, { name: 'MUIDataTableBodyRows' })(TableBodyRows);


### PR DESCRIPTION
Work in progress. At this moment this is more of a proof-of-concept than a fully fleshed out new feature. You can see the Grouping feature live at the below link by selecting the "Grouping" example (once the project has loaded):

https://codesandbox.io/s/github/gregnb/mui-datatables/tree/groupings

At the moment I'm taking cues from React Grid's Grouping feature: https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/grouping/

What's left to do:
- Add an optional drag dashboard for column headers, so groupings can dynamically be made.
- Figure out how rowsPerPage should work (probably rowsPerPage will work with top level groups).
- Figure out how serverSide=true will deal with groups (users will probably need to supply the possible groups).
- Iron out details of feature + get user feedback.
- Make sure everything works and nothing gets/got broken.
- Add tests.
- Clean up code.

This is a pretty big feature, so I want to get it right. Please let me know if you have any feedback.