### PR TITLE
Bug fix for resizable columns and draggable columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.2.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",
   "files": [

--- a/src/hooks/useColumnDrop.js
+++ b/src/hooks/useColumnDrop.js
@@ -26,7 +26,7 @@ const getColModel = (headCellRefs, columnOrder, columns) => {
     parentOffsetLeft = 0,
     offsetParent = leftMostCell.offsetParent;
   while (offsetParent) {
-    parentOffsetLeft = parentOffsetLeft + (offsetParent.offsetLeft || 0);
+    parentOffsetLeft = parentOffsetLeft + (offsetParent.offsetLeft || 0) - (offsetParent.scrollLeft || 0);
     offsetParent = offsetParent.offsetParent;
     ii++;
     if (ii > 1000) break;


### PR DESCRIPTION
This PR contains the following fixes:

* Fix for making draggable columns work properly when there is a scroll offset on the table (ex: a table with 20 columns where one scrolls to the right to see columns).
* Fix for resizable columns when certain columns are hidden. Also implements a better fix for selectableRows="none" (which was put into 3.3.0).