### PR TITLE
feat($general): make TableFilter swappable

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -10,6 +10,7 @@ import merge from 'lodash.merge';
 import PropTypes from 'prop-types';
 import React from 'react';
 import DefaultTableBody from './components/TableBody';
+import DefaultTableFilter from './components/TableFilter';
 import DefaultTableFilterList from './components/TableFilterList';
 import DefaultTableFooter from './components/TableFooter';
 import DefaultTableHead from './components/TableHead';
@@ -254,6 +255,7 @@ class MUIDataTable extends React.Component {
     columns: [],
     components: {
       TableBody: DefaultTableBody,
+      TableFilter: DefaultTableFilter,
       TableFilterList: DefaultTableFilterList,
       TableFooter: DefaultTableFooter,
       TableHead: DefaultTableHead,

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -294,6 +294,7 @@ class TableToolbar extends React.Component {
 
     const Tooltip = components.Tooltip || MuiTooltip;
     const TableViewColComponent = components.TableViewCol || TableViewCol;
+    const TableFilterComponent = components.TableFilter || TableFilter;
     const { search, downloadCsv, print, viewColumns, filterTable } = options.textLabels.toolbar;
     const { showSearch, searchText } = this.state;
 
@@ -305,6 +306,7 @@ class TableToolbar extends React.Component {
     const closeFilterPopover = () => {
       this.setState({ hideFilterPopover: true });
     };
+
 
     return (
       <Toolbar
@@ -424,7 +426,7 @@ class TableToolbar extends React.Component {
                 </Tooltip>
               }
               content={
-                <TableFilter
+                <TableFilterComponent
                   customFooter={options.customFilterDialogFooter}
                   columns={columns}
                   options={options}


### PR DESCRIPTION
This pull request makes the `TableFilter` component swappable from client code. This is very useful in cases when special customizations needs to be done in the filter dialog. The alternative to this is overriding the `TableToolbar` component and swap `TableFilter` from there, which is not desirable at all.