### PR TITLE
Bugfix/1479: Return Correct filterPos using Deep-Object Equality

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import assignwith from 'lodash.assignwith';
 import cloneDeep from 'lodash.clonedeep';
 import find from 'lodash.find';
+import isEqual from 'lodash.isequal';
 import isUndefined from 'lodash.isundefined';
 import merge from 'lodash.merge';
 import PropTypes from 'prop-types';
@@ -1369,7 +1370,7 @@ class MUIDataTable extends React.Component {
   };
 
   updateFilterByType = (filterList, index, value, type, customUpdate) => {
-    const filterPos = filterList[index].indexOf(value);
+    const filterPos = filterList[index].findIndex(filter => isEqual(filter, value));
 
     switch (type) {
       case 'checkbox':


### PR DESCRIPTION
Issue Ticket: #1479 

The library is already pulling in `lodash.isequal`, so I decided to leverage that function for a deep-object comparison in the `Array.findIndex()` function predicate.

Personally, I think it would be better to either: pass in a custom comparator as a prop, or return the filter `value` instead of `filterPos` to allow the user to define their own logic in `update()`. However, the deep-object comparison method does not break any existing contracts/functionality or require adding an additional prop.