### PR TITLE
Fallback for falsy customRowRender

### DIFF
--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -241,7 +241,10 @@ class TableBody extends React.Component {
             const { data: row, dataIndex } = data;
 
             if (options.customRowRender) {
-              return options.customRowRender(row, dataIndex, rowIndex);
+              const customRowRenderResult = options.customRowRender(row, dataIndex, rowIndex);
+              if (customRowRenderResult) {
+                return customRowRenderResult;
+              }
             }
 
             let isRowSelected = options.selectableRows !== 'none' ? this.isRowSelected(dataIndex) : false;


### PR DESCRIPTION
If you want to apply a customRowRender only to a specific row you can fallback to the default renderer by returning falsy result from customRowRender. It might be useful when you want to edit a specific line (render inputs instead of values).

Maybe the PR should also introduce a new option `fallbackCustomRowRender` to not create a breaking change. Currently returning `null` simply doesn't render the row.