### PR TITLE
Add support for 'any match' filter for array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The component accepts the following props:
 |**`expandableRowsHeader`**|boolean|true|Show/hide the expand all/collapse all row header for expandable rows.
 |**`expandableRowsOnClick`**|boolean|false|Enable/disable expand trigger when row is clicked. When False, only expand icon will trigger this action.
 |**`filter`**|boolean|true|Show/hide filter icon from toolbar.
+|**`filterArrayFullMatch`**|boolean|true|For array values, default checks if all the filter values are included in the array. If false, checks if at least one of the filter values is in the array.
 |**`filterType`**|string||Choice of filtering view. `enum('checkbox', 'dropdown', 'multiselect', 'textField', 'custom')`
 |**`fixedHeader`**|boolean|true|Enable/disable a fixed header for the table [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js)
 |**`fixedSelectColumn`**|boolean|true|Enable/disable fixed select column. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/fixed-header/index.js)

--- a/examples/array-value-columns/index.js
+++ b/examples/array-value-columns/index.js
@@ -1,108 +1,123 @@
-import React from "react";
+import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src";
 import Chip from '@material-ui/core/Chip';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
 
-class Example extends React.Component {
+function Example() {
+  // const allTags = ['leave-message', 'frequently-busy', 'nice', 'grumpy', 'in-person', 'preferred', 'second-choice'];
+  const [filterArrayFullMatch, setFilterArrayFullMatch] = useState(true);
 
-  render() {
-    // const allTags = ['leave-message', 'frequently-busy', 'nice', 'grumpy', 'in-person', 'preferred', 'second-choice'];
-    const columns = [
-      {
-        name: "Name",
-        options: {
-          filter: true,
-          display: 'excluded',
-        }
-      },      
-      {
-        label: "Modified Title Label",
-        name: "Title",
-        options: {
-          filter: true,
-        }
-      },
-      {
-        name: "Location",
-        options: {
-          print: false,
-          filter: false,
-        }
-      },
-      {
-        name: "Age",
-        options: {
-          filter: true,
-          print: false,
-        }
-      },
-      {
-        name: "Salary",
-        options: {
-          filter: true,
-          sort: false
-        }
-      },
-      {
-        name: 'Tags',
-        options: {
-            filter: true,
-            filterType: 'multiselect',
-            customBodyRenderLite: (dataIndex) => {
-                let value = data[dataIndex][5];
-                return value.map( (val, key) => {
-                    return <Chip label={val} key={key} />;
-                });
-            },
-        }
-      },
-    ];
+  const columns = [
+    {
+      name: "Name",
+      options: {
+        filter: true,
+        display: 'excluded',
+      }
+    },
+    {
+      label: "Modified Title Label",
+      name: "Title",
+      options: {
+        filter: true,
+      }
+    },
+    {
+      name: "Location",
+      options: {
+        print: false,
+        filter: false,
+      }
+    },
+    {
+      name: "Age",
+      options: {
+        filter: true,
+        print: false,
+      }
+    },
+    {
+      name: "Salary",
+      options: {
+        filter: true,
+        sort: false
+      }
+    },
+    {
+      name: 'Tags',
+      options: {
+        filter: true,
+        filterType: 'multiselect',
+        customBodyRenderLite: (dataIndex) => {
+          let value = data[dataIndex][5];
+          return value.map((val, key) => {
+            return <Chip label={val} key={key} />;
+          });
+        },
+      }
+    },
+  ];
 
 
-    const data = [
-      ["Gabby George", "Business Analyst", "Minneapolis", 30, "$100,000", ['nice', 'preferred']],
-      ["Aiden Lloyd", "Business Consultant", "Dallas",  55, "$200,000", ['grumpy', 'second-choice']],
-      ["Jaden Collins", "Attorney", "Santa Ana", 27, "$500,000", ['frequently-busy', 'leave-message']],
-      ["Franky Rees", "Business Analyst", "St. Petersburg", 22, "$50,000", ['in-person', 'nice']],
-      ["Aaren Rose", "Business Consultant", "Toledo", 28, "$75,000", ['preferred']],
-      ["Blake Duncan", "Business Management Analyst", "San Diego", 65, "$94,000", ['nice']],
-      ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, "$210,000", ['nice', 'preferred']],
-      ["Lane Wilson", "Commercial Specialist", "Omaha", 19, "$65,000", ['frequently-busy', 'leave-message']],
-      ["Robin Duncan", "Business Analyst", "Los Angeles", 20, "$77,000", ['frequently-busy', 'leave-message', 'nice']],
-      ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, "$135,000", ['grumpy', 'second-choice']],
-      ["Harper White", "Attorney", "Pittsburgh", 52, "$420,000", ['preferred']],
-      ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, "$150,000", ['preferred']],
-      ["Frankie Long", "Industrial Analyst", "Austin", 31, "$170,000", ['preferred']],
-      ["Brynn Robbins", "Business Analyst", "Norfolk", 22, "$90,000", ['preferred']],
-      ["Justice Mann", "Business Consultant", "Chicago", 24, "$133,000", ['preferred']],
-      ["Addison Navarro", "Business Management Analyst", "New York", 50, "$295,000", ['preferred']],
-      ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, "$200,000", ['preferred']],
-      ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, "$400,000", ['preferred']],
-      ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, "$110,000", ['preferred']],
-      ["Danny Leon", "Computer Scientist", "Newark", 60, "$220,000", ['preferred']],
-      ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, "$180,000", ['preferred']],
-      ["Jesse Hall", "Business Analyst", "Baltimore", 44, "$99,000", ['preferred']],
-      ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, "$90,000", ['preferred']],
-      ["Terry Macdonald", "Commercial Specialist", "Miami", 39, "$140,000", ['preferred']],
-      ["Justice Mccarthy", "Attorney", "Tucson", 26, "$330,000", ['preferred']],
-      ["Silver Carey", "Computer Scientist", "Memphis", 47, "$250,000" , ['preferred']],
-      ["Franky Miles", "Industrial Analyst", "Buffalo", 49, "$190,000", ['preferred']],
-      ["Glen Nixon", "Corporate Counselor", "Arlington", 44, "$80,000", ['preferred']],
-      ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, "$45,000", ['preferred']],
-      ["Mason Ray", "Computer Scientist", "San Francisco", 39, "$142,000", ['preferred']]
-    ];
+  const data = [
+    ["Gabby George", "Business Analyst", "Minneapolis", 30, "$100,000", ['nice', 'preferred']],
+    ["Aiden Lloyd", "Business Consultant", "Dallas", 55, "$200,000", ['grumpy', 'second-choice']],
+    ["Jaden Collins", "Attorney", "Santa Ana", 27, "$500,000", ['frequently-busy', 'leave-message']],
+    ["Franky Rees", "Business Analyst", "St. Petersburg", 22, "$50,000", ['in-person', 'nice']],
+    ["Aaren Rose", "Business Consultant", "Toledo", 28, "$75,000", ['preferred']],
+    ["Blake Duncan", "Business Management Analyst", "San Diego", 65, "$94,000", ['nice']],
+    ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, "$210,000", ['nice', 'preferred']],
+    ["Lane Wilson", "Commercial Specialist", "Omaha", 19, "$65,000", ['frequently-busy', 'leave-message']],
+    ["Robin Duncan", "Business Analyst", "Los Angeles", 20, "$77,000", ['frequently-busy', 'leave-message', 'nice']],
+    ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, "$135,000", ['grumpy', 'second-choice']],
+    ["Harper White", "Attorney", "Pittsburgh", 52, "$420,000", ['preferred']],
+    ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, "$150,000", ['preferred']],
+    ["Frankie Long", "Industrial Analyst", "Austin", 31, "$170,000", ['preferred']],
+    ["Brynn Robbins", "Business Analyst", "Norfolk", 22, "$90,000", ['preferred']],
+    ["Justice Mann", "Business Consultant", "Chicago", 24, "$133,000", ['preferred']],
+    ["Addison Navarro", "Business Management Analyst", "New York", 50, "$295,000", ['preferred']],
+    ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, "$200,000", ['preferred']],
+    ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, "$400,000", ['preferred']],
+    ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, "$110,000", ['preferred']],
+    ["Danny Leon", "Computer Scientist", "Newark", 60, "$220,000", ['preferred']],
+    ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, "$180,000", ['preferred']],
+    ["Jesse Hall", "Business Analyst", "Baltimore", 44, "$99,000", ['preferred']],
+    ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, "$90,000", ['preferred']],
+    ["Terry Macdonald", "Commercial Specialist", "Miami", 39, "$140,000", ['preferred']],
+    ["Justice Mccarthy", "Attorney", "Tucson", 26, "$330,000", ['preferred']],
+    ["Silver Carey", "Computer Scientist", "Memphis", 47, "$250,000", ['preferred']],
+    ["Franky Miles", "Industrial Analyst", "Buffalo", 49, "$190,000", ['preferred']],
+    ["Glen Nixon", "Corporate Counselor", "Arlington", 44, "$80,000", ['preferred']],
+    ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, "$45,000", ['preferred']],
+    ["Mason Ray", "Computer Scientist", "San Francisco", 39, "$142,000", ['preferred']]
+  ];
 
-    const options = {
-      filter: true,
-      filterType: 'dropdown',
-      responsive: 'standard',
-    };
+  const options = {
+    filter: true,
+    filterArrayFullMatch: filterArrayFullMatch,
+    filterType: 'dropdown',
+    responsive: 'standard',
+  };
 
-    return (
+  return (
+    <>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={filterArrayFullMatch}
+            onChange={e => setFilterArrayFullMatch(e.target.checked)}
+            value="filterArray"
+            color="primary"
+          />
+        }
+        label="Fullmatch for Array filter"
+      />
       <MUIDataTable title={"ACME Employee list"} data={data} columns={columns} options={options} />
-    );
+    </>
+  );
 
-  }
 }
 
 export default Example;

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -190,6 +190,7 @@ class MUIDataTable extends React.Component {
         }),
       }),
       filter: PropTypes.bool,
+      filterArrayFullMatch: PropTypes.bool,
       filterType: PropTypes.oneOf(['dropdown', 'checkbox', 'multiselect', 'textField', 'custom']),
       fixedHeader: PropTypes.bool,
       fixedSelectColumn: PropTypes.bool,
@@ -275,8 +276,8 @@ class MUIDataTable extends React.Component {
     this.draggableHeadCellRefs = {};
     this.resizeHeadCellRefs = {};
     this.timers = {};
-    this.setHeadResizeable = () => {};
-    this.updateDividers = () => {};
+    this.setHeadResizeable = () => { };
+    this.updateDividers = () => { };
 
     let defaultState = {
       activeColumn: null,
@@ -392,6 +393,7 @@ class MUIDataTable extends React.Component {
     expandableRowsHeader: true,
     expandableRowsOnClick: false,
     filter: true,
+    filterArrayFullMatch: true,
     filterType: 'dropdown',
     fixedHeader: true,
     fixedSelectColumn: true,
@@ -448,12 +450,12 @@ class MUIDataTable extends React.Component {
       ) {
         this.warnDep(
           this.options.responsive +
-            ' has been deprecated, but will still work in version 3.x. Please use string option: standard | vertical | simple. More info: https://github.com/gregnb/mui-datatables/tree/master/docs/v2_to_v3_guide.md',
+          ' has been deprecated, but will still work in version 3.x. Please use string option: standard | vertical | simple. More info: https://github.com/gregnb/mui-datatables/tree/master/docs/v2_to_v3_guide.md',
         );
       } else {
         this.warnInfo(
           this.options.responsive +
-            ' is not recognized as a valid input for responsive option. Please use string option: standard | vertical | simple. More info: https://github.com/gregnb/mui-datatables/tree/master/docs/v2_to_v3_guide.md',
+          ' is not recognized as a valid input for responsive option. Please use string option: standard | vertical | simple. More info: https://github.com/gregnb/mui-datatables/tree/master/docs/v2_to_v3_guide.md',
         );
       }
     }
@@ -672,19 +674,19 @@ class MUIDataTable extends React.Component {
 
     const transformedData = Array.isArray(data[0])
       ? data.map(row => {
-          let i = -1;
+        let i = -1;
 
-          return columns.map(col => {
-            if (!col.empty) i++;
-            return col.empty ? undefined : row[i];
-          });
-        })
+        return columns.map(col => {
+          if (!col.empty) i++;
+          return col.empty ? undefined : row[i];
+        });
+      })
       : data.map(row => columns.map(col => leaf(row, col.name)));
 
     return transformedData;
   };
 
-  setTableData(props, status, dataUpdated, callback = () => {}, fromConstructor = false) {
+  setTableData(props, status, dataUpdated, callback = () => { }, fromConstructor = false) {
     let tableData = [];
     let { columns, filterData, filterList, columnOrder } = this.buildColumns(
       props.columns,
@@ -972,8 +974,8 @@ class MUIDataTable extends React.Component {
           typeof funcResult === 'string' || !funcResult
             ? funcResult
             : funcResult.props && funcResult.props.value
-            ? funcResult.props.value
-            : columnValue;
+              ? funcResult.props.value
+              : columnValue;
 
         displayRow.push(columnDisplay);
       } else {
@@ -997,13 +999,23 @@ class MUIDataTable extends React.Component {
         ) {
           isFiltered = true;
         } else if (filterType !== 'textField' && Array.isArray(columnValue)) {
-          //true if every filterVal exists in columnVal, false otherwise
-          const isFullMatch = filterVal.every(el => {
-            return columnValue.indexOf(el) >= 0;
-          });
-          //if it is not a fullMatch, filter row out
-          if (!isFullMatch) {
-            isFiltered = true;
+          if (options.filterArrayFullMatch) {
+            //true if every filterVal exists in columnVal, false otherwise
+            const isFullMatch = filterVal.every(el => {
+              return columnValue.indexOf(el) >= 0;
+            });
+            //if it is not a fullMatch, filter row out
+            if (!isFullMatch) {
+              isFiltered = true;
+            }
+          } else {
+            const isAnyMatch = filterVal.some(el => {
+              return columnValue.indexOf(el) >= 0;
+            });
+            //if no value matches, filter row out
+            if (!isAnyMatch) {
+              isFiltered = true;
+            }
           }
         }
       }
@@ -1357,13 +1369,13 @@ class MUIDataTable extends React.Component {
           displayData: this.options.serverSide
             ? prevState.displayData
             : this.getDisplayData(
-                prevState.columns,
-                prevState.data,
-                filterList,
-                prevState.searchText,
-                null,
-                this.props,
-              ),
+              prevState.columns,
+              prevState.data,
+              filterList,
+              prevState.searchText,
+              null,
+              this.props,
+            ),
         };
       },
       () => {
@@ -1415,13 +1427,13 @@ class MUIDataTable extends React.Component {
           displayData: this.options.serverSide
             ? prevState.displayData
             : this.getDisplayData(
-                prevState.columns,
-                prevState.data,
-                filterList,
-                prevState.searchText,
-                null,
-                this.props,
-              ),
+              prevState.columns,
+              prevState.data,
+              filterList,
+              prevState.searchText,
+              null,
+              this.props,
+            ),
           previousSelectedRow: null,
         };
       },
@@ -1957,15 +1969,15 @@ class MUIDataTable extends React.Component {
         <div style={{ position: 'relative', ...tableHeightVal }} className={responsiveClass}>
           {(this.options.resizableColumns === true ||
             (this.options.resizableColumns && this.options.resizableColumns.enabled)) && (
-            <TableResizeComponent
-              key={rowCount}
-              columnOrder={columnOrder}
-              updateDividers={fn => (this.updateDividers = fn)}
-              setResizeable={fn => (this.setHeadResizeable = fn)}
-              options={this.props.options}
-              tableId={this.options.tableId}
-            />
-          )}
+              <TableResizeComponent
+                key={rowCount}
+                columnOrder={columnOrder}
+                updateDividers={fn => (this.updateDividers = fn)}
+                setResizeable={fn => (this.setHeadResizeable = fn)}
+                options={this.props.options}
+                tableId={this.options.tableId}
+              />
+            )}
           <DndProvider backend={HTML5Backend} {...dndProps}>
             <MuiTable
               ref={el => (this.tableRef = el)}
@@ -2017,12 +2029,12 @@ class MUIDataTable extends React.Component {
               />
               {this.options.customTableBodyFooterRender
                 ? this.options.customTableBodyFooterRender({
-                    data: displayData,
-                    count: rowCount,
-                    columns,
-                    selectedRows,
-                    selectableRows: this.options.selectableRows,
-                  })
+                  data: displayData,
+                  count: rowCount,
+                  columns,
+                  selectedRows,
+                  selectableRows: this.options.selectableRows,
+                })
                 : null}
             </MuiTable>
           </DndProvider>


### PR DESCRIPTION
This adds a "filterArrayFullMatch" option to the table that defaults to true, to decide how to handle array filtering.

Default remains the same : if you have several filter values selected, for a row to show, the column value needs to include every filter values.
If filterArrayFullMatch is false though, then we check if at least one of the filter values is in the column value.

I made some changes to the array-value-columns example to include both use cases, I changed the example component to be a function which is why the commit is a bit long.

I thought this use case I added should be pretty common, and would be interesting to add support for.
Also this is my first PR, so let me know if you're interested with this option, and if so tell me if anything is wrong.