### PR TITLE
Adding title props in both backIconButtonProps and nextIconButtonProps

### DIFF
--- a/examples/text-localization/index.js
+++ b/examples/text-localization/index.js
@@ -49,6 +49,10 @@ class Example extends React.Component {
         body: {
           noMatch: "Sorry we could not find any records!",
         },
+        pagination:{
+          next: "Following page",
+          privous: "Preceding page"
+        },
         filter: {
           all: "All Records",
           title: "OUR FILTERS",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4080,7 +4080,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -15598,7 +15599,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -80,11 +80,13 @@ function TablePagination(props) {
                 id: 'pagination-back',
                 'data-testid': 'pagination-back',
                 'aria-label': textLabels.previous,
+                title: textLabels.previous,
               }}
               nextIconButtonProps={{
                 id: 'pagination-next',
                 'data-testid': 'pagination-next',
                 'aria-label': textLabels.next,
+                title: textLabels.next,
               }}
               SelectProps={{
                 id: 'pagination-input',


### PR DESCRIPTION
Hello, guys. This is my first Github contribution. I noticed that the textLabel for 'next' and 'previous' were not being applied in the titles for the 'nex't and 'previous' buttons in the pagination area. Only the aria-label were being applied. So, I made this correction to add both titles. Please, let me know if you need anymore information on this PR.