### PR TITLE
Allow custom react-dnd backend

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1803,7 +1803,16 @@ class MUIDataTable extends React.Component {
       classes,
       className,
       title,
-      components: { TableBody, TableFilterList, TableFooter, TableHead, TableResize, TableToolbar, TableToolbarSelect },
+      components: {
+        TableBody,
+        TableFilterList,
+        TableFooter,
+        TableHead,
+        TableResize,
+        TableToolbar,
+        TableToolbarSelect,
+        DragDropBackend = HTML5Backend,
+      },
     } = this.props;
     const {
       announceText,
@@ -1966,66 +1975,75 @@ class MUIDataTable extends React.Component {
               tableId={this.options.tableId}
             />
           )}
-          <DndProvider backend={HTML5Backend} {...dndProps}>
-            <MuiTable
-              ref={el => (this.tableRef = el)}
-              tabIndex={'0'}
-              role={'grid'}
-              className={tableClassNames}
-              {...tableProps}>
-              <caption className={classes.caption}>{title}</caption>
-              <TableHeadComponent
-                columns={columns}
-                activeColumn={activeColumn}
-                data={displayData}
-                count={rowCount}
-                page={page}
-                rowsPerPage={rowsPerPage}
-                selectedRows={selectedRows}
-                selectRowUpdate={this.selectRowUpdate}
-                toggleSort={this.toggleSortColumn}
-                setCellRef={this.setHeadCellRef}
-                expandedRows={expandedRows}
-                areAllRowsExpanded={this.areAllRowsExpanded}
-                toggleAllExpandableRows={this.toggleAllExpandableRows}
-                options={this.options}
-                sortOrder={sortOrder}
-                columnOrder={columnOrder}
-                updateColumnOrder={this.updateColumnOrder}
-                draggableHeadCellRefs={this.draggableHeadCellRefs}
-                tableRef={this.getTableContentRef}
-                tableId={this.options.tableId}
-                timers={this.timers}
-                components={this.props.components}
-              />
-              <TableBodyComponent
-                data={displayData}
-                count={rowCount}
-                columns={columns}
-                page={page}
-                rowsPerPage={rowsPerPage}
-                selectedRows={selectedRows}
-                selectRowUpdate={this.selectRowUpdate}
-                previousSelectedRow={previousSelectedRow}
-                expandedRows={expandedRows}
-                toggleExpandRow={this.toggleExpandRow}
-                options={this.options}
-                columnOrder={columnOrder}
-                filterList={filterList}
-                components={this.props.components}
-                tableId={this.options.tableId}
-              />
-              {this.options.customTableBodyFooterRender
-                ? this.options.customTableBodyFooterRender({
-                    data: displayData,
-                    count: rowCount,
-                    columns,
-                    selectedRows,
-                    selectableRows: this.options.selectableRows,
-                  })
-                : null}
-            </MuiTable>
-          </DndProvider>
+          {(() => {
+            const components = (
+                <MuiTable
+                ref={el => (this.tableRef = el)}
+                tabIndex={'0'}
+                role={'grid'}
+                className={tableClassNames}
+                {...tableProps}>
+                <caption className={classes.caption}>{title}</caption>
+                <TableHeadComponent
+                  columns={columns}
+                  activeColumn={activeColumn}
+                  data={displayData}
+                  count={rowCount}
+                  page={page}
+                  rowsPerPage={rowsPerPage}
+                  selectedRows={selectedRows}
+                  selectRowUpdate={this.selectRowUpdate}
+                  toggleSort={this.toggleSortColumn}
+                  setCellRef={this.setHeadCellRef}
+                  expandedRows={expandedRows}
+                  areAllRowsExpanded={this.areAllRowsExpanded}
+                  toggleAllExpandableRows={this.toggleAllExpandableRows}
+                  options={this.options}
+                  sortOrder={sortOrder}
+                  columnOrder={columnOrder}
+                  updateColumnOrder={this.updateColumnOrder}
+                  draggableHeadCellRefs={this.draggableHeadCellRefs}
+                  tableRef={this.getTableContentRef}
+                  tableId={this.options.tableId}
+                  timers={this.timers}
+                  components={this.props.components}
+                />
+                <TableBodyComponent
+                  data={displayData}
+                  count={rowCount}
+                  columns={columns}
+                  page={page}
+                  rowsPerPage={rowsPerPage}
+                  selectedRows={selectedRows}
+                  selectRowUpdate={this.selectRowUpdate}
+                  previousSelectedRow={previousSelectedRow}
+                  expandedRows={expandedRows}
+                  toggleExpandRow={this.toggleExpandRow}
+                  options={this.options}
+                  columnOrder={columnOrder}
+                  filterList={filterList}
+                  components={this.props.components}
+                  tableId={this.options.tableId}
+                />
+                {this.options.customTableBodyFooterRender
+                  ? this.options.customTableBodyFooterRender({
+                      data: displayData,
+                      count: rowCount,
+                      columns,
+                      selectedRows,
+                      selectableRows: this.options.selectableRows,
+                    })
+                  : null}
+              </MuiTable>
+            );
+            if (DragDropBackend) {
+              return (
+                <DndProvider backend={DragDropBackend} {...dndProps}>{components}</DndProvider>
+              );
+            }
+
+            return components;
+          })()}
         </div>
         <TableFooterComponent
           options={this.options}

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -106,6 +106,11 @@ const TableHeadCell = ({
   const sortActive = sortDirection !== 'none' && sortDirection !== undefined;
   const ariaSortDirection = sortDirection === 'none' ? false : sortDirection;
 
+  const isDraggingEnabled = () => {
+    if (!draggingHook) return false;
+    return options.draggableColumns && options.draggableColumns.enabled && column.draggable !== false;
+  };
+
   const sortLabelProps = {
     classes: { root: classes.sortLabelRoot },
     active: sortActive,
@@ -113,7 +118,7 @@ const TableHeadCell = ({
     ...(ariaSortDirection ? { direction: sortDirection } : {}),
   };
 
-  const [{ opacity }, dragRef, preview] = useDrag({
+  const [{ opacity }, dragRef, preview] = isDraggingEnabled()? useDrag({
     item: {
       type: 'HEADER',
       colIndex: index,
@@ -135,9 +140,9 @@ const TableHeadCell = ({
         opacity: monitor.isDragging() ? 1 : 0,
       };
     },
-  });
+  }) : [{}];
 
-  const [drop] = useColumnDrop({
+  const [drop] = isDraggingEnabled()? useColumnDrop({
     drop: (item, mon) => {
       setSortTooltipOpen(false);
       setHintTooltipOpen(false);
@@ -152,12 +157,7 @@ const TableHeadCell = ({
     tableRef: tableRef ? tableRef() : null,
     tableId: tableId || 'none',
     timers,
-  });
-
-  const isDraggingEnabled = () => {
-    if (!draggingHook) return false;
-    return options.draggableColumns && options.draggableColumns.enabled && column.draggable !== false;
-  };
+  }) : [];
 
   const cellClass = clsx({
     [classes.root]: true,
@@ -187,7 +187,7 @@ const TableHeadCell = ({
   return (
     <TableCell
       ref={ref => {
-        drop(ref);
+        drop && drop(ref);
         setCellRef && setCellRef(index + 1, colPosition + 1, ref);
       }}
       className={cellClass}


### PR DESCRIPTION
This pull request actually has two desired outcomes

1) I'm using react-dnd in other components with a different backend for IE performance reasons - i'd like to use my custom backend everywhere

2) I was having issues initially and wanted to just disable loading the drag-and-drop component from even loading - this now enabled that by passing  components={{DragDropBackend: null}}