### PR TITLE
Fixed @material-ui/icons imports to allow tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "3.7.2",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server -d --progress --colors",
     "test": "cross-env NODE_ENV=test mocha --require @babel/register test/**/*.test.js",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.7.2",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",
-  "files": [	
-    "dist"	
+  "files": [
+    "dist"
   ],
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server -d --progress --colors",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.7.2",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",
+  "files": [	
+    "dist"	
+  ],
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server -d --progress --colors",
     "test": "cross-env NODE_ENV=test mocha --require @babel/register test/**/*.test.js",

--- a/src/components/ExpandButton.js
+++ b/src/components/ExpandButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { IconButton } from '@material-ui/core';
-import { KeyboardArrowRight, Remove } from '@material-ui/icons';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+import RemoveIcon from '@material-ui/icons/Remove';
 
 const ExpandButton = ({
   areAllRowsExpanded,
@@ -20,7 +21,7 @@ const ExpandButton = ({
           style={{ padding: 0 }}
           disabled={expandableRowsHeader === false}
           className={buttonClass}>
-          <Remove id="expandable-button" className={iconIndeterminateClass} />
+          <RemoveIcon id="expandable-button" className={iconIndeterminateClass} />
         </IconButton>
       ) : (
         <IconButton
@@ -28,7 +29,7 @@ const ExpandButton = ({
           style={{ padding: 0 }}
           disabled={expandableRowsHeader === false}
           className={buttonClass}>
-          <KeyboardArrowRight id="expandable-button" className={iconClass} />
+          <KeyboardArrowRightIcon id="expandable-button" className={iconClass} />
         </IconButton>
       )}
     </>


### PR DESCRIPTION
## The Issue
Per Material UI's guide on minimizing bundle size, It appears a recent mui-datatables update [#1591](https://github.com/gregnb/mui-datatables/issues/1591) broke tree-shaking by importing material icons incorrectly.  This PR attempts to remedy that so projects importing mui-datatables aren't bloated by importing the full icon set.

Example:
```javascript
// uses tree-shaking, only imports the Remove icon
import RemoveIcon from '@material-ui/icons/Remove';
// imports all of @material-ui/icons (requires a Babel plugin to only include the Remove icon)
import { Remove } from '@material-ui/icons';
```

## Reasoning
I came upon this issue when trying to reduce the bundle size of one of my projects and found that the full icon set was still being included even though I followed the Material UI guide.  I searched through the entire bundle and found the cause.  The import syntax in  [#1591](https://github.com/gregnb/mui-datatables/issues/1591) can still allow for tree-shaking with the inclusion of a Babel plugin, but I figured the rest of mui-datatables used the explicit syntax which does not require any help from Babel to keep the bundle size minimal.

## Reference
Commit using unoptimized import syntax:
https://github.com/gregnb/mui-datatables/issues/1591

Material UI guide reference:
https://material-ui.com/guides/minimizing-bundle-size/