### PR TITLE
ensure ids are unique when rendering multiple tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.7.2",
+  "version": "3.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6328,9 +6328,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001066",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001066.tgz",
-      "integrity": "sha512-Gfj/WAastBtfxLws0RCh2sDbTK/8rJuSeZMecrSkNGYxPcv7EzblmDGfWQCFEQcSqYE2BRgQiJh8HOD07N5hIw==",
+      "version": "1.0.30001189",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001189.tgz",
+      "integrity": "sha512-BSfxClP/UWCD0RX1h1L+vLDexNSJY7SfOtbJtW10bcnatfj3BcoietUFYNwWreOCk+SNvGUaNapGqUNPiGAiSA==",
       "dev": true
     },
     "caseless": {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -359,8 +359,8 @@ class MUIDataTable extends React.Component {
       props.options.selectToolbarPlacement = STP.NONE;
     }
 
-    // provide default tableId when draggableColumns is enabled and no tableId has been passed as prop
-    if (props.options.draggableColumns && props.options.draggableColumns.enabled === true && !props.options.tableId) {
+    // provide default tableId when no tableId has been passed as prop
+    if (!props.options.tableId) {
       props.options.tableId = (Math.random() + '').replace(/\./, '');
     }
 

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -267,7 +267,7 @@ class TableBody extends React.Component {
                     [bodyClasses.className]: bodyClasses.className,
                   })}
                   data-testid={'MUIDataTableBodyRow-' + dataIndex}
-                  id={'MUIDataTableBodyRow-' + dataIndex}>
+                  id={`MUIDataTableBodyRow-${tableId}-${dataIndex}`}>
                   <TableSelectCell
                     onChange={this.handleRowSelect.bind(null, {
                       index: this.getRowIndex(rowIndex),
@@ -289,7 +289,7 @@ class TableBody extends React.Component {
                     isRowExpanded={this.isRowExpanded(dataIndex)}
                     isRowSelectable={isRowSelectable}
                     dataIndex={dataIndex}
-                    id={'MUIDataTableSelectCell-' + dataIndex}
+                    id={`MUIDataTableSelectCell-${tableId}-${dataIndex}`}
                     components={components}
                   />
                   {processedRow.map(

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -6,7 +6,6 @@ import TableHeadCell from './TableHeadCell';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
 
-
 const useStyles = makeStyles(
   theme => ({
     main: {},

--- a/test/MUIDataTable.test.js
+++ b/test/MUIDataTable.test.js
@@ -17,6 +17,7 @@ import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 
 describe('<MUIDataTable />', function() {
+  const tableId = 'tableID';
   let data;
   let displayData;
   let columns;
@@ -1988,10 +1989,10 @@ describe('<MUIDataTable />', function() {
       expandableRowsOnClick: true,
       onRowExpansionChange: spy(),
     };
-    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} tableId={tableId} />);
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -1999,7 +2000,7 @@ describe('<MUIDataTable />', function() {
     assert(options.onRowExpansionChange.calledWith([{ index: 2, dataIndex: 2 }], [{ index: 2, dataIndex: 2 }]));
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -2013,10 +2014,10 @@ describe('<MUIDataTable />', function() {
       selectableRowsOnClick: true,
       onRowSelectionChange: spy(),
     };
-    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} />);
+    const mountWrapper = mount(<MUIDataTable columns={columns} data={data} options={options} tableId={tableId} />);
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -2024,7 +2025,7 @@ describe('<MUIDataTable />', function() {
     assert(options.onRowSelectionChange.calledWith([{ index: 2, dataIndex: 2 }], [{ index: 2, dataIndex: 2 }]));
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 

--- a/test/MUIDataTableBody.test.js
+++ b/test/MUIDataTableBody.test.js
@@ -11,6 +11,7 @@ describe('<TableBody />', function() {
   let data;
   let displayData;
   let columns;
+  const tableId = 'tableID';
 
   before(() => {
     columns = [{ name: 'First Name' }, { name: 'Company' }, { name: 'City' }, { name: 'State' }];
@@ -227,11 +228,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-3')
+      .find(`#MUIDataTableBodyRow-${tableId}-3`)
       .first()
       .simulate('click', { nativeEvent: { shiftKey: true } });
 
@@ -258,11 +260,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -295,11 +298,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -334,11 +338,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -374,11 +379,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -414,11 +420,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-1')
+      .find(`#MUIDataTableBodyRow-${tableId}-1`)
       .first()
       .simulate('click');
 
@@ -453,11 +460,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -485,11 +493,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -524,11 +533,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -617,11 +627,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     mountWrapper
-      .find('#MUIDataTableBodyRow-2')
+      .find(`#MUIDataTableBodyRow-${tableId}-2`)
       .first()
       .simulate('click');
 
@@ -648,11 +659,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     const props = mountWrapper
-      .find('#MUIDataTableBodyRow-1')
+      .find(`#MUIDataTableBodyRow-${tableId}-1`)
       .first()
       .props();
 
@@ -680,11 +692,12 @@ describe('<TableBody />', function() {
         options={options}
         searchText={''}
         filterList={[]}
+        tableId={tableId}
       />,
     );
 
     const props = mountWrapper
-      .find('#MUIDataTableBodyRow-1')
+      .find(`#MUIDataTableBodyRow-${tableId}-1`)
       .first()
       .props();
 

--- a/test/MUIDataTableToolbarCustomIcons.test.js
+++ b/test/MUIDataTableToolbarCustomIcons.test.js
@@ -61,17 +61,16 @@ const data = [
 
 const testCustomIcon = iconName => {
   const components = { icons: { [iconName]: CustomChip } };
-  const wrapper = mount(<TableToolbar {...{columns, data, options, setTableAction, components}} />);
+  const wrapper = mount(<TableToolbar {...{ columns, data, options, setTableAction, components }} />);
   assert.strictEqual(wrapper.find(IconButton).length, 5); // All icons show
   assert.strictEqual(wrapper.find(CustomChip).length, 1); // Custom chip shows once
   Object.keys(icons).forEach(icon => {
     // The original default for the custom icon should be gone, the rest should remain
-    assert.strictEqual(wrapper.find(icons[icon]).length, iconName === icon ? 0 : 1); 
+    assert.strictEqual(wrapper.find(icons[icon]).length, iconName === icon ? 0 : 1);
   });
 };
 
 describe('<TableToolbar /> with custom icons', function() {
-
   it('should render a toolbar with a custom chip in place of the search icon', () => {
     testCustomIcon('SearchIcon');
   });
@@ -91,5 +90,4 @@ describe('<TableToolbar /> with custom icons', function() {
   it('should render a toolbar with a custom chip in place of the filter icon', () => {
     testCustomIcon('FilterIcon');
   });
-
 });


### PR DESCRIPTION
- auto generated the unique table id if not passed regardless of other options
- added tableId to row and cell id prop to ensure ids are unique if there are multiple tables in a page

