### PR TITLE
No dnd backend provided

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -35,6 +35,7 @@ import CustomComponents from './custom-components';
 import InfiniteScrolling from './infinite-scrolling';
 import Themes from './themes';
 import LargeDataSet from './large-data-set';
+import NoDND from './no-drag-and-drop';
 
 /**
  * Here you can add any extra examples with the Card label as the key, and the component to render as the value
@@ -65,6 +66,7 @@ export default {
   'Hide Columns Print': HideColumnsPrint,
   'Infinite Scrolling': InfiniteScrolling,
   'Large Data Set': LargeDataSet,
+  'No Drag and Drop': NoDND,
   'OnDownload': OnDownload,
   'OnTableInit': OnTableInit,
   'Resizable Columns': ResizableColumns,

--- a/examples/no-drag-and-drop/index.js
+++ b/examples/no-drag-and-drop/index.js
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
+import MUIDataTable from "../../src";
+import Chip from '@material-ui/core/Chip';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
+
+function Example() {
+  // const allTags = ['leave-message', 'frequently-busy', 'nice', 'grumpy', 'in-person', 'preferred', 'second-choice'];
+  const [filterArrayFullMatch, setFilterArrayFullMatch] = useState(true);
+
+  const columns = [
+    {
+      name: "Name",
+      options: {
+        filter: true,
+        display: 'excluded',
+      }
+    },
+    {
+      label: "Modified Title Label",
+      name: "Title",
+      options: {
+        filter: true,
+      }
+    },
+    {
+      name: "Location",
+      options: {
+        print: false,
+        filter: false,
+      }
+    },
+    {
+      name: "Age",
+      options: {
+        filter: true,
+        print: false,
+      }
+    },
+    {
+      name: "Salary",
+      options: {
+        filter: true,
+        sort: false
+      }
+    },
+    {
+      name: 'Tags',
+      options: {
+        filter: true,
+        filterType: 'multiselect',
+        customBodyRenderLite: (dataIndex) => {
+          let value = data[dataIndex][5];
+          return value.map((val, key) => {
+            return <Chip label={val} key={key} />;
+          });
+        },
+      }
+    },
+  ];
+
+
+  const data = [
+    ["Gabby George", "Business Analyst", "Minneapolis", 30, "$100,000", ['nice', 'preferred']],
+    ["Aiden Lloyd", "Business Consultant", "Dallas", 55, "$200,000", ['grumpy', 'second-choice']],
+    ["Jaden Collins", "Attorney", "Santa Ana", 27, "$500,000", ['frequently-busy', 'leave-message']],
+    ["Franky Rees", "Business Analyst", "St. Petersburg", 22, "$50,000", ['in-person', 'nice']],
+    ["Aaren Rose", "Business Consultant", "Toledo", 28, "$75,000", ['preferred']],
+    ["Blake Duncan", "Business Management Analyst", "San Diego", 65, "$94,000", ['nice']],
+    ["Frankie Parry", "Agency Legal Counsel", "Jacksonville", 71, "$210,000", ['nice', 'preferred']],
+    ["Lane Wilson", "Commercial Specialist", "Omaha", 19, "$65,000", ['frequently-busy', 'leave-message']],
+    ["Robin Duncan", "Business Analyst", "Los Angeles", 20, "$77,000", ['frequently-busy', 'leave-message', 'nice']],
+    ["Mel Brooks", "Business Consultant", "Oklahoma City", 37, "$135,000", ['grumpy', 'second-choice']],
+    ["Harper White", "Attorney", "Pittsburgh", 52, "$420,000", ['preferred']],
+    ["Kris Humphrey", "Agency Legal Counsel", "Laredo", 30, "$150,000", ['preferred']],
+    ["Frankie Long", "Industrial Analyst", "Austin", 31, "$170,000", ['preferred']],
+    ["Brynn Robbins", "Business Analyst", "Norfolk", 22, "$90,000", ['preferred']],
+    ["Justice Mann", "Business Consultant", "Chicago", 24, "$133,000", ['preferred']],
+    ["Addison Navarro", "Business Management Analyst", "New York", 50, "$295,000", ['preferred']],
+    ["Jesse Welch", "Agency Legal Counsel", "Seattle", 28, "$200,000", ['preferred']],
+    ["Eli Mejia", "Commercial Specialist", "Long Beach", 65, "$400,000", ['preferred']],
+    ["Gene Leblanc", "Industrial Analyst", "Hartford", 34, "$110,000", ['preferred']],
+    ["Danny Leon", "Computer Scientist", "Newark", 60, "$220,000", ['preferred']],
+    ["Lane Lee", "Corporate Counselor", "Cincinnati", 52, "$180,000", ['preferred']],
+    ["Jesse Hall", "Business Analyst", "Baltimore", 44, "$99,000", ['preferred']],
+    ["Danni Hudson", "Agency Legal Counsel", "Tampa", 37, "$90,000", ['preferred']],
+    ["Terry Macdonald", "Commercial Specialist", "Miami", 39, "$140,000", ['preferred']],
+    ["Justice Mccarthy", "Attorney", "Tucson", 26, "$330,000", ['preferred']],
+    ["Silver Carey", "Computer Scientist", "Memphis", 47, "$250,000", ['preferred']],
+    ["Franky Miles", "Industrial Analyst", "Buffalo", 49, "$190,000", ['preferred']],
+    ["Glen Nixon", "Corporate Counselor", "Arlington", 44, "$80,000", ['preferred']],
+    ["Gabby Strickland", "Business Process Consultant", "Scottsdale", 26, "$45,000", ['preferred']],
+    ["Mason Ray", "Computer Scientist", "San Francisco", 39, "$142,000", ['preferred']]
+  ];
+
+  const options = {
+    filter: true,
+    filterArrayFullMatch: filterArrayFullMatch,
+    filterType: 'dropdown',
+    responsive: 'standard',
+  };
+
+  return (
+    <>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={filterArrayFullMatch}
+            onChange={e => setFilterArrayFullMatch(e.target.checked)}
+            value="filterArray"
+            color="primary"
+          />
+        }
+        label="Fullmatch for Array filter"
+      />
+      <MUIDataTable
+        title={"ACME Employee list"}
+        data={data}
+        columns={columns}
+        options={options}
+        components={{DragDropBackend: null}}
+      />
+    </>
+  );
+
+}
+
+export default Example;

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -3,6 +3,7 @@ import { TableHead as MuiTableHead } from '@material-ui/core';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import TableHeadCell from './TableHeadCell';
+import TableHeadCellNoDnD from './TableHeadCellNoDnD';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
 
@@ -48,6 +49,10 @@ const TableHead = ({
   updateColumnOrder,
 }) => {
   const classes = useStyles();
+
+  const isDraggingEnabled = () => {
+    return options.draggableColumns && options.draggableColumns.enabled;
+  };
 
   if (columnOrder === null) {
     columnOrder = columns ? columns.map((item, idx) => idx) : [];
@@ -134,35 +139,60 @@ const TableHead = ({
             (column.customHeadRender ? (
               column.customHeadRender({ index, ...column }, handleToggleColumn, sortOrder)
             ) : (
-              <TableHeadCell
-                cellHeaderProps={
-                  columns[index].setCellHeaderProps ? columns[index].setCellHeaderProps({ index, ...column }) || {} : {}
-                }
-                key={index}
-                index={index}
-                colPosition={colPos}
-                type={'cell'}
-                setCellRef={setCellRef}
-                sort={column.sort}
-                sortDirection={column.name === sortOrder.name ? sortOrder.direction : 'none'}
-                toggleSort={handleToggleColumn}
-                hint={column.hint}
-                print={column.print}
-                options={options}
-                column={column}
-                columns={columns}
-                updateColumnOrder={updateColumnOrder}
-                columnOrder={columnOrder}
-                timers={timers}
-                draggingHook={[dragging, setDragging]}
-                draggableHeadCellRefs={draggableHeadCellRefs}
-                tableRef={tableRef}
-                tableId={tableId}
-                components={components}>
-                {column.customHeadLabelRender
-                  ? column.customHeadLabelRender({ index, colPos, ...column })
-                  : column.label}
-              </TableHeadCell>
+              (isDraggingEnabled()) ? (
+                <TableHeadCell
+                  cellHeaderProps={
+                    columns[index].setCellHeaderProps ? columns[index].setCellHeaderProps({ index, ...column }) || {} : {}
+                  }
+                  key={index}
+                  index={index}
+                  colPosition={colPos}
+                  type={'cell'}
+                  setCellRef={setCellRef}
+                  sort={column.sort}
+                  sortDirection={column.name === sortOrder.name ? sortOrder.direction : 'none'}
+                  toggleSort={handleToggleColumn}
+                  hint={column.hint}
+                  print={column.print}
+                  options={options}
+                  column={column}
+                  columns={columns}
+                  updateColumnOrder={updateColumnOrder}
+                  columnOrder={columnOrder}
+                  timers={timers}
+                  draggingHook={[dragging, setDragging]}
+                  draggableHeadCellRefs={draggableHeadCellRefs}
+                  tableRef={tableRef}
+                  tableId={tableId}
+                  components={components}>
+                  {column.customHeadLabelRender
+                    ? column.customHeadLabelRender({ index, colPos, ...column })
+                    : column.label}
+                </TableHeadCell>
+              ) : (
+                <TableHeadCellNoDnD
+                  cellHeaderProps={
+                    columns[index].setCellHeaderProps ? columns[index].setCellHeaderProps({ index, ...column }) || {} : {}
+                  }
+                  key={index}
+                  index={index}
+                  colPosition={colPos}
+                  type={'cell'}
+                  setCellRef={setCellRef}
+                  sort={column.sort}
+                  sortDirection={column.name === sortOrder.name ? sortOrder.direction : 'none'}
+                  toggleSort={handleToggleColumn}
+                  hint={column.hint}
+                  print={column.print}
+                  options={options}
+                  column={column}
+                  tableId={tableId}
+                  components={components}>
+                  {column.customHeadLabelRender
+                    ? column.customHeadLabelRender({ index, colPos, ...column })
+                    : column.label}
+                </TableHeadCellNoDnD>
+              )
             )),
         )}
       </TableHeadRow>

--- a/src/components/TableHeadCellNoDnD.js
+++ b/src/components/TableHeadCellNoDnD.js
@@ -6,9 +6,9 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import useColumnDrop from '../hooks/useColumnDrop.js';
+
 import { makeStyles } from '@material-ui/core/styles';
-import { useDrag } from 'react-dnd';
+
 
 const useStyles = makeStyles(
   theme => ({
@@ -64,16 +64,12 @@ const useStyles = makeStyles(
   { name: 'MUIDataTableHeadCell' },
 );
 
-const TableHeadCell = ({
+const TableHeadCellNoDnD = ({
   cellHeaderProps = {},
   children,
   colPosition,
   column,
-  columns,
-  columnOrder = [],
   components = {},
-  draggableHeadCellRefs,
-  draggingHook,
   hint,
   index,
   options,
@@ -81,11 +77,8 @@ const TableHeadCell = ({
   setCellRef,
   sort,
   sortDirection,
-  tableRef,
   tableId,
-  timers,
   toggleSort,
-  updateColumnOrder,
 }) => {
   const [sortTooltipOpen, setSortTooltipOpen] = useState(false);
   const [hintTooltipOpen, setHintTooltipOpen] = useState(false);
@@ -104,17 +97,10 @@ const TableHeadCell = ({
     toggleSort(index);
   };
 
-  const [dragging, setDragging] = draggingHook ? draggingHook : [];
-
   const { className, ...otherProps } = cellHeaderProps;
   const Tooltip = components.Tooltip || MuiTooltip;
   const sortActive = sortDirection !== 'none' && sortDirection !== undefined;
   const ariaSortDirection = sortDirection === 'none' ? false : sortDirection;
-
-  const isDraggingEnabled = () => {
-    if (!draggingHook) return false;
-    return column.draggable !== false;
-  };
 
   const sortLabelProps = {
     classes: { root: classes.sortLabelRoot },
@@ -123,47 +109,6 @@ const TableHeadCell = ({
     hideSortIcon: true,
     ...(ariaSortDirection ? { direction: sortDirection } : {}),
   };
-
-  const [{ opacity }, dragRef, preview] = useDrag({
-    item: {
-      type: 'HEADER',
-      colIndex: index,
-      headCellRefs: draggableHeadCellRefs,
-    },
-    begin: monitor => {
-      setTimeout(() => {
-        setHintTooltipOpen(false);
-        setSortTooltipOpen(false);
-        setDragging(true);
-      }, 0);
-      return null;
-    },
-    end: (item, monitor) => {
-      setDragging(false);
-    },
-    collect: monitor => {
-      return {
-        opacity: monitor.isDragging() ? 1 : 0,
-      };
-    },
-  });
-
-  const [drop] = useColumnDrop({
-    drop: (item, mon) => {
-      setSortTooltipOpen(false);
-      setHintTooltipOpen(false);
-      setDragging(false);
-    },
-    index,
-    headCellRefs: draggableHeadCellRefs,
-    updateColumnOrder,
-    columnOrder,
-    columns,
-    transitionTime: options.draggableColumns ? options.draggableColumns.transitionTime : 300,
-    tableRef: tableRef ? tableRef() : null,
-    tableId: tableId || 'none',
-    timers,
-  });
 
   const cellClass = clsx({
     [classes.root]: true,
@@ -177,22 +122,9 @@ const TableHeadCell = ({
     setHintTooltipOpen(true);
   };
 
-  const getTooltipTitle = () => {
-    if (dragging) return '';
-    if (!options.textLabels) return '';
-    return options.textLabels.body.columnHeaderTooltip
-      ? options.textLabels.body.columnHeaderTooltip(column)
-      : options.textLabels.body.toolTip;
-  };
-
-  const closeTooltip = () => {
-    setSortTooltipOpen(false);
-  };
-
   return (
     <TableCell
       ref={ref => {
-        drop && drop(ref);
         setCellRef && setCellRef(index + 1, colPosition + 1, ref);
       }}
       className={cellClass}
@@ -200,15 +132,14 @@ const TableHeadCell = ({
       sortDirection={ariaSortDirection}
       data-colindex={index}
       data-tableid={tableId}
-      onMouseDown={closeTooltip}
       {...otherProps}>
       {options.sort && sort ? (
         <span className={classes.contentWrapper}>
           <Tooltip
-            title={getTooltipTitle()}
+            title=''
             placement="bottom"
             open={sortTooltipOpen}
-            onOpen={() => (dragging ? setSortTooltipOpen(false) : setSortTooltipOpen(true))}
+            onOpen={() => setSortTooltipOpen(true)}
             onClose={() => setSortTooltipOpen(false)}
             classes={{
               tooltip: classes.tooltip,
@@ -220,13 +151,12 @@ const TableHeadCell = ({
               onClick={handleSortClick}
               className={classes.toolButton}
               data-testid={`headcol-${index}`}
-              ref={isDraggingEnabled() ? dragRef : null}>
+              ref={null}>
               <div className={classes.sortAction}>
                 <div
                   className={clsx({
                     [classes.data]: true,
                     [classes.sortActive]: sortActive,
-                    [classes.dragCursor]: isDraggingEnabled(),
                   })}>
                   {children}
                 </div>
@@ -246,7 +176,7 @@ const TableHeadCell = ({
           )}
         </span>
       ) : (
-        <div className={hint ? classes.sortAction : null} ref={isDraggingEnabled() ? dragRef : null}>
+        <div className={hint ? classes.sortAction : null} ref={null}>
           {children}
           {hint && (
             <Tooltip
@@ -269,7 +199,7 @@ const TableHeadCell = ({
   );
 };
 
-TableHeadCell.propTypes = {
+TableHeadCellNoDnD.propTypes = {
   /** Options used to describe table */
   options: PropTypes.object.isRequired,
   /** Current sort direction */
@@ -288,4 +218,4 @@ TableHeadCell.propTypes = {
   components: PropTypes.object,
 };
 
-export default TableHeadCell;
+export default TableHeadCellNoDnD;


### PR DESCRIPTION
This PR follows #1536 which allows to manage cases where no DND backend is provided. 

The original PR conditionally called the hooks "useDrag" and "useColumnDrop" in the TableHeadCell component, but it seems that these changes have been overwritten in commit e75d2fe. Therefore, a bug appears in the TableHeadCell component if no DnDbackend is provided (which is quite a neat feature).

So I propose a quickfix in which I created a new component named TableHeadCellNoDnd which is called if dragNDrop is not explicitly enabled.

I added a working example of a table to which is passed "components={{DragDropBackend: null}}".