### PR TITLE
Search always open

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The component accepts the following props:
 |**`searchPlaceholder`**|string||Search text placeholder. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
 |**`searchProps`**|object|{}|Props applied to the search text box. You can set method callbacks like onBlur, onKeyUp, etc, this way. [Example](https://github.com/gregnb/mui-datatables/blob/master/examples/customize-search/index.js)
 |**`searchOpen`**|boolean|false|Initially displays search bar.
+|**`searchAlwaysOpen`**|boolean|false|Always displays search bar, and hides search icon in toolbar.
 |**`searchText`**|string||Search text for the table.
 |**`selectableRows`**|string|'multiple'|Indicates if rows can be selected. Options are "multiple", "single", "none".
 |**`selectableRowsHeader`**|boolean|true|Show/hide the select all/deselect all checkbox header for selectable rows.

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -231,6 +231,7 @@ class MUIDataTable extends React.Component {
       rowsSelected: PropTypes.array,
       search: PropTypes.oneOf([true, false, 'true', 'false', 'disabled']),
       searchOpen: PropTypes.bool,
+      searchAlwaysOpen: PropTypes.bool,
       searchPlaceholder: PropTypes.string,
       searchText: PropTypes.string,
       setFilterChipProps: PropTypes.func,

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -6,7 +6,6 @@ import TableHeadCell from './TableHeadCell';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
 
-
 const useStyles = makeStyles(
   theme => ({
     main: {},

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -6,6 +6,7 @@ import TableHeadCell from './TableHeadCell';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
 
+
 const useStyles = makeStyles(
   theme => ({
     main: {},

--- a/src/components/TableSearch.js
+++ b/src/components/TableSearch.js
@@ -42,6 +42,8 @@ const TableSearch = ({ options, searchText, onSearch, onHide }) => {
     }
   };
 
+  const clearIconVisibility = options.searchAlwaysOpen ? 'hidden' : 'visible';
+
   return (
     <Grow appear in={true} timeout={300}>
       <div className={classes.main}>
@@ -62,7 +64,7 @@ const TableSearch = ({ options, searchText, onSearch, onHide }) => {
           placeholder={options.searchPlaceholder}
           {...(options.searchProps ? options.searchProps : {})}
         />
-        <IconButton className={classes.clearIcon} onClick={onHide}>
+        <IconButton className={classes.clearIcon} style={{ visibility: clearIconVisibility }} onClick={onHide}>
           <ClearIcon />
         </IconButton>
       </div>

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -107,7 +107,12 @@ const RESPONSIVE_FULL_WIDTH_NAME = 'scrollFullHeightFullWidth';
 class TableToolbar extends React.Component {
   state = {
     iconActive: null,
-    showSearch: Boolean(this.props.searchText || this.props.options.searchText || this.props.options.searchOpen),
+    showSearch: Boolean(
+      this.props.searchText ||
+        this.props.options.searchText ||
+        this.props.options.searchOpen ||
+        this.props.options.searchAlwaysOpen,
+    ),
     searchText: this.props.searchText || null,
   };
 
@@ -344,7 +349,7 @@ class TableToolbar extends React.Component {
           )}
         </div>
         <div className={options.responsive !== RESPONSIVE_FULL_WIDTH_NAME ? classes.actions : classes.fullWidthActions}>
-          {!(options.search === false || options.search === 'false') && (
+          {!(options.search === false || options.search === 'false' || options.searchAlwaysOpen === true) && (
             <Tooltip title={search} disableFocusListener>
               <IconButton
                 aria-label={search}

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -3,6 +3,7 @@ import DownloadIcon from '@material-ui/icons/CloudDownload';
 import FilterIcon from '@material-ui/icons/FilterList';
 import PrintIcon from '@material-ui/icons/Print';
 import SearchIcon from '@material-ui/icons/Search';
+import CloseIcon from "@material-ui/icons/Close";
 import ViewColumnIcon from '@material-ui/icons/ViewColumn';
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
@@ -100,6 +101,26 @@ describe('<TableToolbar />', function() {
     );
     const actualResult = mountWrapper.find(SearchIcon);
     assert.strictEqual(actualResult.length, 0);
+  });
+
+  it('should render a toolbar with search box and no search icon if option.searchAlwaysOpen = true', () => {
+    const newOptions = { ...options, searchAlwaysOpen: true };
+    const mountWrapper = mount(
+        <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
+    );
+
+    // check that textfield is rendered
+    const actualTextfieldResult = mountWrapper.find(TableSearch);
+    assert.strictEqual(actualTextfieldResult.length, 1);
+    assert.strictEqual(actualTextfieldResult.props().options.searchText, undefined);
+
+    // check that close icon is not rendered
+    const actualCloseIconResult = mountWrapper.find(CloseIcon());
+    assert.strictEqual(actualCloseIconResult.length, 1);
+
+    // check that search icon is rendered
+    const actualSearchIconResult = mountWrapper.find(SearchIcon);
+    assert.strictEqual(actualSearchIconResult.length, 0);
   });
 
   it('should render a toolbar with no download icon if option.download = false', () => {

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -116,7 +116,7 @@ describe('<TableToolbar />', function() {
 
     // check that close icon is not rendered
     const actualCloseIconResult = mountWrapper.find(CloseIcon());
-    assert.strictEqual(actualCloseIconResult.length, 1);
+    assert.strictEqual(actualCloseIconResult.length, 0);
 
     // check that search icon is rendered
     const actualSearchIconResult = mountWrapper.find(SearchIcon);


### PR DESCRIPTION
Related to #1125 and #1686

This adds the option to have the search bar always open. This sets the search bar to be open and removes the close option. It also removes the search icon from the toolbar, since that would allow the search bar to be closed. An alternative would be to keep the icon but disable its on click, would be happy to make that change if that's preferred.