### PR TITLE
Removing top level imports to reduce bundle sizes.

### DIFF
--- a/src/components/ExpandButton.js
+++ b/src/components/ExpandButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconButton } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import RemoveIcon from '@material-ui/icons/Remove';
 

--- a/src/components/JumpToPage.js
+++ b/src/components/JumpToPage.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InputBase, MenuItem, Select, Toolbar, Typography } from '@material-ui/core';
+import InputBase from '@material-ui/core/InputBase';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { getPageValue } from '../utils.js';
 import clsx from 'clsx';

--- a/src/components/TableFilter.js
+++ b/src/components/TableFilter.js
@@ -1,10 +1,9 @@
-import { Grid, TextField } from '@material-ui/core';
-
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
+import Grid from '@material-ui/core/Grid';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -12,6 +11,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -1,11 +1,10 @@
 import { makeStyles } from '@material-ui/core/styles';
-import { TableHead as MuiTableHead } from '@material-ui/core';
 import clsx from 'clsx';
+import MuiTableHead from '@material-ui/core/TableHead';
 import React, { useState } from 'react';
 import TableHeadCell from './TableHeadCell';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
-
 
 const useStyles = makeStyles(
   theme => ({

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { Checkbox, TableCell } from '@material-ui/core';
+import Checkbox from '@material-ui/core/Checkbox';
+import TableCell from '@material-ui/core/TableCell';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandButton from './ExpandButton';
 


### PR DESCRIPTION
I performed a text search for anything importing `from '@material-ui/core` and replaced the results with second level imports, so that the entire @material-ui/core directory is not pulled into bundles.