### PR TITLE
cut out space in data-testid for automation tools

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -360,7 +360,7 @@ class TableToolbar extends React.Component {
           {!(options.download === false || options.download === 'false') && (
             <Tooltip title={downloadCsv}>
               <IconButton
-                data-testid={downloadCsv + '-iconButton'}
+                data-testid={downloadCsv.replace(/\s/g, '') + '-iconButton'}
                 aria-label={downloadCsv}
                 classes={{ root: classes.icon }}
                 disabled={options.download === 'disabled'}


### PR DESCRIPTION
my company's QA team couldnt select the download csv button using the cypress automation testing tool because there was a space in the localization config of downloadCsv.

this fix makes it so that you can use whatever localization text you want and remove the whitespaces only in the data-testid attributes.