### PR TITLE
Get state saving and loading to work

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -23,6 +23,7 @@ import getTextLabels from './textLabels';
 import { buildMap, getCollatorComparator, getPageValue, sortCompare, warnDeprecated, warnInfo } from './utils';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { load, save } from './localStorage';
 
 const defaultTableStyles = theme => ({
   root: {},
@@ -244,6 +245,7 @@ class MUIDataTable extends React.Component {
       setTableProps: PropTypes.func,
       sort: PropTypes.bool,
       sortOrder: PropTypes.object,
+      storageKey: PropTypes.string,
       viewColumns: PropTypes.oneOf([true, false, 'true', 'false', 'disabled']),
     }),
     /** Pass and use className to style MUIDataTable as desired */
@@ -307,7 +309,10 @@ class MUIDataTable extends React.Component {
     };
 
     this.mergeDefaultOptions(props);
-    this.state = Object.assign(defaultState, this.getInitTableOptions());
+
+    const restoredState = load(props.options.storageKey);
+    this.state = Object.assign(defaultState, restoredState ? restoredState : this.getInitTableOptions());
+
     this.setTableData = this.setTableData.bind(this);
 
     this.setTableData(props, TABLE_LOAD.INITIAL, true, null, true);
@@ -543,6 +548,9 @@ class MUIDataTable extends React.Component {
   setTableAction = action => {
     if (typeof this.options.onTableChange === 'function') {
       this.options.onTableChange(action, this.state);
+    }
+    if (this.options.storageKey) {
+      save(this.options.storageKey, this.state);
     }
   };
 

--- a/src/localStorage/index.js
+++ b/src/localStorage/index.js
@@ -1,0 +1,2 @@
+export { load } from './load';
+export { save } from './save';

--- a/src/localStorage/load.js
+++ b/src/localStorage/load.js
@@ -1,0 +1,1 @@
+export const load = storageKey => JSON.parse(window.localStorage.getItem(storageKey));

--- a/src/localStorage/save.js
+++ b/src/localStorage/save.js
@@ -1,0 +1,5 @@
+export const save = (storageKey, state) => {
+  const { selectedRows, data, displayData, ...savedState } = state;
+
+  window.localStorage.setItem(storageKey, JSON.stringify(savedState));
+};


### PR DESCRIPTION
Hi,

I think it could be nice to have a save state to local storage feature. That way the reopened table will restore its state with search text, filtering and sorting.

Added a storageKey option, type string. State is saved on every change, only if the option is present.