### PR TITLE
fix(#1747): Replace deprecated props in mui based components

### DIFF
--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -59,8 +59,7 @@ const Popover = ({ className, trigger, refExit, hide, content, ...providedProps 
       <MuiPopover
         elevation={2}
         open={isOpen}
-        onClose={handleRequestClose}
-        onExited={handleOnExit}
+        TransitionProps={{ onExited: handleOnExit, onClose: handleRequestClose }}
         anchorEl={anchorEl.current}
         anchorOrigin={anchorOriginSpecs}
         transformOrigin={transformOriginSpecs}

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -98,8 +98,8 @@ function TablePagination(props) {
                 },
               }}
               rowsPerPageOptions={options.rowsPerPageOptions}
-              onChangePage={handlePageChange}
-              onChangeRowsPerPage={handleRowChange}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowChange}
             />
           </div>
         </MuiTableCell>

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -349,7 +349,7 @@ class TableToolbar extends React.Component {
               <IconButton
                 aria-label={search}
                 data-testid={search + '-iconButton'}
-                buttonRef={el => (this.searchButton = el)}
+                ref={el => (this.searchButton = el)}
                 classes={{ root: this.getActiveIcon(classes, 'search') }}
                 disabled={options.search === 'disabled'}
                 onClick={this.handleSearchIconClick}>


### PR DESCRIPTION
[Material-ui](https://next.material-ui.com/) will be [migrating from v4 to v5 ](https://next.material-ui.com/guides/migration-v4/) and has been deprecating stuffs as a part of that move. Deprecation warnings as stated in #1747 appears when MUI-Datatable is used. This PR fixes it by using the recommendations provided by material-ui, in regards to the deprecations.

- Used `TransitionProps` instead of the [deprecated `onClose` and `onExited` Props](https://next.material-ui.com/guides/migration-v4/#popover) for material-ui based Popover.

- Used `onPageChange` and `onRowsPageChange` Props instead of the [deprecated `onChangePage` and `onChangeRowsPerPage` ](https://next.material-ui.com/guides/migration-v4/#table)Props respectively, for material-ui based TablePagination. 

- Used `ref` instead of the deprecated `buttonRef `for material-ui based IconButton. Note: In addition to those mentioned in  #1747, I faced the below warning as well:

     > Warning: Failed prop type: The prop `buttonRef` of `ForwardRef(ButtonBase)` is deprecated. Use `ref` instead..

     If I am not wrong, I believe it is caused by the warnings added in [material ui 4.12.0 release](https://github.com/mui-org/material-ui/releases/tag/v4.12.0) and there are indeed going to remove `buttonRef` as seen in[ one of the v5 pre-releases.](https://github.com/mui-org/material-ui/releases/tag/v5.0.0-alpha.32#:~:text=%5Bbuttonbase%5D%20remove%20buttonref%20prop%20(%2325896)%20%40m4theushw)
     
I tried running the `npm test`, however, I faced the same error as mentioned in  [here](https://github.com/gregnb/mui-datatables/pull/1718#issuecomment-840667925).