### PR TITLE
fix: searchAlwaysOpen when clicking other filters

### DIFF
--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -222,6 +222,9 @@ class TableToolbar extends React.Component {
   isSearchShown = iconName => {
     let nextVal = false;
     if (this.state.showSearch) {
+      if (this.props.options.searchAlwaysOpen) {
+        return true;
+      }
       if (this.state.searchText) {
         nextVal = true;
       } else {


### PR DESCRIPTION
#1770 
I think this line should do the trick, but not sure if  I missing something