### PR TITLE
Search always open fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.7.8",
+  "version": "3.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-datatables",
-  "version": "3.7.6",
+  "version": "3.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -220,6 +220,10 @@ class TableToolbar extends React.Component {
   };
 
   isSearchShown = iconName => {
+    if (this.props.options.searchAlwaysOpen) {
+      return true;
+    }
+
     let nextVal = false;
     if (this.state.showSearch) {
       if (this.state.searchText) {

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -3,7 +3,7 @@ import DownloadIcon from '@material-ui/icons/CloudDownload';
 import FilterIcon from '@material-ui/icons/FilterList';
 import PrintIcon from '@material-ui/icons/Print';
 import SearchIcon from '@material-ui/icons/Search';
-import CloseIcon from "@material-ui/icons/Close";
+import CloseIcon from '@material-ui/icons/Close';
 import ViewColumnIcon from '@material-ui/icons/ViewColumn';
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
@@ -106,7 +106,7 @@ describe('<TableToolbar />', function() {
   it('should render a toolbar with search box and no search icon if option.searchAlwaysOpen = true', () => {
     const newOptions = { ...options, searchAlwaysOpen: true };
     const mountWrapper = mount(
-        <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
+      <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
     );
 
     // check that textfield is rendered

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -311,7 +311,7 @@ describe('<TableToolbar />', function() {
 
     let actualResult = shallowWrapper.find(TableSearch);
     assert.strictEqual(actualResult.length, 1);
-  })
+  });
 
   it('should call onFilterDialogOpen when opening filters via toolbar', () => {
     const onFilterDialogOpen = spy();

--- a/test/MUIDataTableToolbar.test.js
+++ b/test/MUIDataTableToolbar.test.js
@@ -3,7 +3,7 @@ import DownloadIcon from '@material-ui/icons/CloudDownload';
 import FilterIcon from '@material-ui/icons/FilterList';
 import PrintIcon from '@material-ui/icons/Print';
 import SearchIcon from '@material-ui/icons/Search';
-import CloseIcon from '@material-ui/icons/Close';
+import CloseIcon from "@material-ui/icons/Close";
 import ViewColumnIcon from '@material-ui/icons/ViewColumn';
 import { assert } from 'chai';
 import { mount, shallow } from 'enzyme';
@@ -106,7 +106,7 @@ describe('<TableToolbar />', function() {
   it('should render a toolbar with search box and no search icon if option.searchAlwaysOpen = true', () => {
     const newOptions = { ...options, searchAlwaysOpen: true };
     const mountWrapper = mount(
-      <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
+        <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
     );
 
     // check that textfield is rendered
@@ -286,6 +286,32 @@ describe('<TableToolbar />', function() {
     actualResult = shallowWrapper.find(TableSearch);
     assert.strictEqual(actualResult.length, 1);
   });
+
+  it('should render a toolbar with a search when searchAlwaysOpen is set to true', () => {
+    const newOptions = { ...options, searchAlwaysOpen: true }
+    const shallowWrapper = shallow(
+        <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
+    ).dive();
+
+    const actualResult = shallowWrapper.find(TableSearch);
+    assert.strictEqual(actualResult.length, 1);
+  });
+
+  it('should not hide search when opening another dialog when searchAlwaysOpen is set to true', () => {
+    const newOptions = { ...options, searchAlwaysOpen: true }
+    const shallowWrapper = shallow(
+        <TableToolbar columns={columns} data={data} options={newOptions} setTableAction={setTableAction} />,
+    ).dive();
+
+    const instance = shallowWrapper.instance();
+
+    instance.setActiveIcon('filter');
+    shallowWrapper.find('[data-testid="Filter Table-iconButton"]').simulate('click');
+    shallowWrapper.update();
+
+    let actualResult = shallowWrapper.find(TableSearch);
+    assert.strictEqual(actualResult.length, 1);
+  })
 
   it('should call onFilterDialogOpen when opening filters via toolbar', () => {
     const onFilterDialogOpen = spy();


### PR DESCRIPTION
Fix issue with the `searchAlwaysOpen` option, as mentioned in the comments on #1691. Search now stays open even when other pop up dialogs (i.e. filters) are open, even if there is no text in the search bar.
Also adds tests for `searchAlwaysOpen`