### PR TITLE
place component in isolated stacking context

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -27,7 +27,9 @@ import { load, save } from './localStorage';
 
 const defaultTableStyles = theme => ({
   root: {},
-  paper: {},
+  paper: {
+    isolation: 'isolate',
+  },
   paperResponsiveScrollFullHeightFullWidth: {
     position: 'absolute',
   },


### PR DESCRIPTION
If the table is placed near tooltips or other elements with z-indexes, some parts of the table (notably the header) can overlap in unexpected ways. Placing the component in an isolated stacking context with `isolation: isolate` makes sure that the z-indexes inside the component only interact with other indexes inside the component, causing the component as a whole to be treated as a single object, which is more coherent and desirable in practically all situations.