### PR TITLE
ToolbarSelect should always shown

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -107,6 +107,7 @@ const STP = {
   REPLACE: 'replace',
   ABOVE: 'above',
   NONE: 'none',
+  ALWAYS: 'always'
 };
 
 class MUIDataTable extends React.Component {
@@ -241,7 +242,7 @@ class MUIDataTable extends React.Component {
       setRowProps: PropTypes.func,
       selectToolbarPlacement: PropTypes.oneOfType([
         PropTypes.bool,
-        PropTypes.oneOf([STP.REPLACE, STP.ABOVE, STP.NONE]),
+        PropTypes.oneOf([STP.REPLACE, STP.ABOVE, STP.NONE, STP.ALWAYS]),
       ]),
       setTableProps: PropTypes.func,
       sort: PropTypes.bool,
@@ -1931,7 +1932,7 @@ class MUIDataTable extends React.Component {
 
     return (
       <Paper elevation={this.options.elevation} ref={this.tableContent} className={paperClasses}>
-        {selectedRows.data.length > 0 && this.options.selectToolbarPlacement !== STP.NONE && (
+        {(this.options.selectToolbarPlacement === STP.ALWAYS || selectedRows.data.length > 0 && this.options.selectToolbarPlacement !== STP.NONE) && (
           <TableToolbarSelectComponent
             options={this.options}
             selectedRows={selectedRows}


### PR DESCRIPTION
Is there a way to show TableToolbarSelect always?
I redefined the TableToolbarSelect component, now I have my own logic for this component, but I also need it to always be on the screen, and it appears only when selecting an object from the table.
I saw the selectToolbarPlacement property that is responsible for showing TableToolbarSelect. Added the always property there. Please do so that I can customize my TableToolbarSelect and be able to show it always.