### PR TITLE
Fixed an issue where empty cells would throw an error

### DIFF
--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -105,6 +105,7 @@ function TableBodyCell(props) {
     className,
     print,
     tableId,
+    isEmpty,
     ...otherProps
   } = props;
   const onCellClick = options.onCellClick;
@@ -173,7 +174,7 @@ function TableBodyCell(props) {
   if (
     ['standard', 'scrollMaxHeight', 'scrollFullHeight', 'scrollFullHeightFullWidth'].indexOf(options.responsive) !==
       -1 ||
-    props.isEmpty
+    isEmpty
   ) {
     innerCells = cells.slice(1, 2);
   } else {


### PR DESCRIPTION
`isEmpty` being in `otherProps` means it was getting passed to `TableCell` which eventually causes a (harmless) warning to be thrown regarding that prop. This removes isEmpty from otherProps and just destructures it like other props.