### PR TITLE
Prevent double sort from Enter key press

### DIFF
--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -91,14 +91,6 @@ const TableHeadCell = ({
 
   const { classes } = useStyles();
 
-  const handleKeyboardSortInput = e => {
-    if (e.key === 'Enter') {
-      toggleSort(index);
-    }
-
-    return false;
-  };
-
   const handleSortClick = () => {
     toggleSort(index);
   };
@@ -215,7 +207,6 @@ const TableHeadCell = ({
             }}>
             <Button
               variant=""
-              onKeyUp={handleKeyboardSortInput}
               onClick={handleSortClick}
               className={classes.toolButton}
               data-testid={`headcol-${index}`}


### PR DESCRIPTION
In the current implementation, using the enter key triggers the sort change twice. Once due to using enter key on a button, which by default (in Chrome at least) triggers that button's onClick, and the second time due to the onKeyUp function. Space bar is currently the work around, but for keyboard only users (blind/low vision) this is broken behavior.