### PR TITLE
Add esm build fixes #2008

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-dnd-html5-backend": "^11.1.3",
         "react-sortable-tree-patch-react-17": "^2.9.0",
         "react-to-print": "^2.8.0",
-        "tss-react": "^3.6.0"
+        "tss-react": "^4.1.3"
       },
       "devDependencies": {
         "@babel/core": "^7.10.2",
@@ -15769,9 +15769,9 @@
       }
     },
     "node_modules/tss-react": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-3.7.1.tgz",
-      "integrity": "sha512-dfWUoxBlKZfIG9UC1A2h02OmcE/Ni0itCmmZu94E9g+KyBhKMHKcsKvUm0bNlRqTmYjXiCgPJDmj5fyc8CSrLg==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.8.6.tgz",
+      "integrity": "sha512-+ucvy+SLFUUxd3zA3QS9Q7bo5FerR8VIUOHieyvYYMoBqtpVinnOA0aTOSXcSdl4lqjFc/9gNA5x0B5iIWk7hA==",
       "dependencies": {
         "@emotion/cache": "*",
         "@emotion/serialize": "*",
@@ -30175,9 +30175,9 @@
       }
     },
     "tss-react": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-3.7.1.tgz",
-      "integrity": "sha512-dfWUoxBlKZfIG9UC1A2h02OmcE/Ni0itCmmZu94E9g+KyBhKMHKcsKvUm0bNlRqTmYjXiCgPJDmj5fyc8CSrLg==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.8.6.tgz",
+      "integrity": "sha512-+ucvy+SLFUUxd3zA3QS9Q7bo5FerR8VIUOHieyvYYMoBqtpVinnOA0aTOSXcSdl4lqjFc/9gNA5x0B5iIWk7hA==",
       "requires": {
         "@emotion/cache": "*",
         "@emotion/serialize": "*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mui-datatables-mara",
+  "name": "mui-datatables",
   "version": "4.3.0",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "mui-datatables",
+  "name": "mui-datatables-mara",
   "version": "4.3.0",
   "description": "Datatables for React using Material-UI",
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
@@ -18,7 +19,7 @@
     "coverage:html": "cross-env NODE_ENV=test nyc check-coverage --lines 55 --reporter=html --reporter=text mocha --require @babel/register test/*.js && nyc report --reporter=html",
     "prettier": "find src/ docs/ test/ -type f -name \"*.js\" ! -path \"*/.next/*\" | xargs prettier --write",
     "lint": "eslint src",
-    "build": "cross-env NODE_ENV=production npm run prettier && rollup -c",
+    "build": "cross-env NODE_ENV=production npm run prettier && rollup -c && rollup -c rollup.esm.config.js",
     "prepare": "npm run build"
   },
   "repository": {
@@ -122,8 +123,7 @@
     "react-dnd": "^11.1.3",
     "react-dnd-html5-backend": "^11.1.3",
     "react-sortable-tree-patch-react-17": "^2.9.0",
-    "react-to-print": "^2.8.0",
-    "tss-react": "^3.6.0"
+    "react-to-print": "^2.8.0"
   },
   "side-effects": false,
   "nyc": {

--- a/rollup.esm.config.js
+++ b/rollup.esm.config.js
@@ -1,0 +1,41 @@
+import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+import uglify from '@lopatnov/rollup-plugin-uglify';
+
+export default {
+  input: 'src/index.js',
+  plugins: [
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+    commonjs({
+      include: ['node_modules/**'],
+    }),
+    babel({
+      babelHelpers: 'runtime',
+      babelrc: true,
+    }),
+    uglify({
+      compress: {
+        conditionals: true,
+        unused: true,
+        comparisons: true,
+        sequences: true,
+        dead_code: true,
+        evaluate: true,
+        if_return: true,
+        join_vars: true,
+      },
+      output: {
+        comments: false,
+      },
+    }),
+  ],
+  output: {
+    file: 'dist/esm/index.js',
+    format: 'esm',
+    exports: 'named',
+    sourcemap: true,
+  },
+};


### PR DESCRIPTION
I have added an esm build which fixes the warning "You are loading @emotion/react when it is already loaded. Running multiple instances may cause problems. This can happen if multiple versions are used, or if multiple builds of the same version are used." when using vite.

I also noticed a duplicate dependency which i have removed.